### PR TITLE
feat(db): update promotion model to support country-level and store-level promotions

### DIFF
--- a/backend/alembic/versions/5256d66b78d3_update_promotion_scope_country_store.py
+++ b/backend/alembic/versions/5256d66b78d3_update_promotion_scope_country_store.py
@@ -1,0 +1,71 @@
+"""update promotion scope country/store
+
+Revision ID: 5256d66b78d3
+Revises: f5d30b494f15
+Create Date: 2026-04-08 19:43:49.907618
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5256d66b78d3'
+down_revision: Union[str, Sequence[str], None] = "4a5403c31464"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "promotion",
+        sa.Column("country_id", sa.Integer(), nullable=False, server_default="1"),
+        schema="pct_core",
+    )
+
+    op.create_foreign_key(
+        "fk_promotion_country",
+        "promotion",
+        "country",
+        ["country_id"],
+        ["id"],
+        source_schema="pct_core",
+        referent_schema="pct_core",
+    )
+
+    op.alter_column(
+        "promotion",
+        "store_id",
+        existing_type=sa.Integer(),
+        nullable=True,
+        schema="pct_core",
+    )
+
+    op.alter_column(
+        "promotion",
+        "country_id",
+        existing_type=sa.Integer(),
+        server_default=None,
+        schema="pct_core",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "promotion",
+        "store_id",
+        existing_type=sa.Integer(),
+        nullable=False,
+        schema="pct_core",
+    )
+
+    op.drop_constraint(
+        "fk_promotion_country",
+        "promotion",
+        schema="pct_core",
+        type_="foreignkey",
+    )
+
+    op.drop_column("promotion", "country_id", schema="pct_core")


### PR DESCRIPTION
## Contexte

Cette PR fait évoluer la table `pct_core.promotion` afin d’aligner le modèle de données avec la règle métier RG09 du cahier des charges.

Jusqu’à présent, une promotion était obligatoirement rattachée à un magasin via `store_id`, ce qui empêchait de représenter une promotion définie au niveau pays.

---

## Objectif

Permettre la gestion de promotions :

* au niveau pays
* au niveau magasin

Cette modification est nécessaire pour aligner la base de données avec le besoin métier réel :

* une promotion pays doit pouvoir exister sans `store_id`
* une promotion doit toujours être liée à un `country_id`

Le problème résolu est l’impossibilité de modéliser une promotion définie uniquement au niveau pays.

---

## Ticket(s) associé(s)

* T22 — Modifier la table `pct_core.promotion` pour gérer les promotions au niveau pays ou magasin

---

## Changements réalisés

* Ajout de la colonne `country_id` dans `pct_core.promotion`
* Ajout de la clé étrangère `fk_promotion_country` vers `pct_core.country(id)`
* Passage de `store_id` en nullable
* Conservation des relations existantes :

  * `fk_promotion_store`
  * `fk_promotion_user`
* Migration Alembic créée et appliquée avec succès
* Vérification manuelle de la nouvelle logique métier

### Logique métier désormais supportée

* Promotion pays → `country_id` renseigné, `store_id = NULL`
* Promotion magasin → `country_id` renseigné, `store_id` renseigné

---

## Tests

* [x] Test manuel effectué
* [ ] Test automatisé (non mis en place à ce stade)

### Étapes de test :

1. Exporter `DATABASE_URL`
2. Exécuter la migration :

```bash
uv run alembic upgrade head
```

3. Vérifier la structure de la table :

```sql
\d pct_core.promotion
```

4. Tester un cas valide de promotion pays :

```sql
INSERT INTO pct_core.promotion (
    code,
    name,
    description,
    discount_type,
    discount_value,
    start_date,
    end_date,
    country_id,
    store_id,
    created_by,
    active
)
VALUES (
    'PROMO-COUNTRY-001',
    'Promotion pays',
    'Promotion définie au niveau pays',
    'PERCENT',
    15.00,
    DATE '2026-05-01',
    DATE '2026-05-15',
    1,
    NULL,
    1,
    TRUE
);
```

5. Tester un cas invalide sans `country_id` :

```sql
INSERT INTO pct_core.promotion (
    code,
    name,
    description,
    discount_type,
    discount_value,
    start_date,
    end_date,
    store_id,
    created_by,
    active
)
VALUES (
    'PROMO-INVALID-001',
    'Promotion invalide',
    'Promotion sans pays',
    'PERCENT',
    10.00,
    DATE '2026-05-01',
    DATE '2026-05-15',
    1,
    1,
    TRUE
);
```

---

## Preuves

### Cas valide

* Insertion d’une promotion pays avec `store_id = NULL` → **OK**

### Cas invalide

* Insertion d’une promotion sans `country_id` → **rejetée**
* erreur PostgreSQL : violation de la contrainte `NOT NULL` sur `country_id`

### Vérification structurelle

* `country_id` ajouté
* `country_id` non nullable
* `store_id` désormais nullable
* FK `fk_promotion_country` présente

---

## Impacts

* [x] Backend
* [ ] Frontend
* [x] Database
* [ ] Data pipeline
* [ ] Aucun impact majeur

### Détails

* Le modèle de données des promotions est désormais aligné avec la logique métier pays / magasin
* Cette évolution prépare les futures règles métier autour des prix promotionnels et du ciblage commercial

---

## Points d’attention

* La cohérence avancée entre `store_id` et `country_id` n’est pas encore contrôlée par contrainte base
* Les promotions existantes ont reçu une valeur de `country_id` via migration avec valeur par défaut transitoire
* Cette PR modifie une table déjà existante et s’appuie sur une migration de structure

---

## Checklist

* [x] Le code fonctionne en local
* [x] Aucun bug connu
* [x] Respect du ticket
* [x] Code lisible et structuré
* [x] Pas de code inutile
* [x] Migration testée (si DB)
* [x] Documentation mise à jour (si nécessaire)

---

## Notes supplémentaires

### Choix techniques

* `country_id` a été ajouté avec un `server_default` temporaire afin de permettre la migration de données existantes
* le `server_default` a ensuite été retiré pour conserver une structure propre
* aucun champ `promotion_scope` n’a été ajouté : la portée est déduite de la présence ou non de `store_id`

### Limites actuelles

* absence de contrainte croisée entre `store_id` et `country_id`
* pas encore de validation métier avancée sur les dates ou le chevauchement des promotions

### Améliorations futures possibles

* ajout de contraintes métier complémentaires
* ajout de validations applicatives côté API
* documentation explicite de RG09 dans le runbook ou le modèle de données
