### PR TITLE
Develop

### DIFF
--- a/data/dbt/models/intermediate/int.yml
+++ b/data/dbt/models/intermediate/int.yml
@@ -1,0 +1,38 @@
+version: 2
+
+models:
+  - name: int_sales_enriched
+    description: "Sales transactions enriched with product, store, price and promotion dimensions"
+    columns:
+      - name: transaction_id
+        description: "Primary key"
+        tests:
+          - unique
+          - not_null
+      - name: transaction_date
+        tests:
+          - not_null
+      - name: product_id
+        tests:
+          - not_null
+      - name: store_id
+        tests:
+          - not_null
+      - name: price_id
+        tests:
+          - not_null
+      - name: product_name
+        tests:
+          - not_null
+      - name: store_name
+        tests:
+          - not_null
+      - name: quantity
+        tests:
+          - not_null
+      - name: unit_price
+        tests:
+          - not_null
+      - name: revenue
+        tests:
+          - not_null

--- a/data/dbt/models/intermediate/int_sales_enriched.sql
+++ b/data/dbt/models/intermediate/int_sales_enriched.sql
@@ -1,0 +1,85 @@
+with sales as (
+
+    select * from {{ ref('stg_sales') }}
+
+),
+
+products as (
+
+    select * from {{ ref('stg_product') }}
+
+),
+
+stores as (
+
+    select * from {{ ref('stg_store') }}
+
+),
+
+prices as (
+
+    select * from {{ ref('stg_price') }}
+
+),
+
+promotions as (
+
+    select * from {{ ref('stg_promotion') }}
+
+),
+
+enriched as (
+
+    select
+        -- Sale
+        s.transaction_id,
+        s.transaction_date,
+        s.quantity,
+        s.unit_price,
+        s.revenue,
+        s.is_promo,
+        s.price_scope,
+        s.price_type,
+
+        -- Product
+        p.product_id,
+        p.product_code,
+        p.product_name,
+        p.brand,
+        p.model,
+        p.product_family_id,
+
+        -- Store
+        st.store_id,
+        st.store_code,
+        st.store_name,
+        st.country_id,
+        st.city,
+        st.region,
+
+        -- Price
+        pr.price_id,
+        pr.price_amount,
+        pr.currency_code,
+        pr.effective_from   as price_effective_from,
+        pr.effective_to     as price_effective_to,
+        pr.price_status,
+
+        -- Promotion
+        promo.promotion_id,
+        promo.promotion_code,
+        promo.promotion_name,
+        promo.discount_type,
+        promo.discount_value,
+        promo.start_date    as promotion_start_date,
+        promo.end_date      as promotion_end_date
+
+    from sales s
+    left join products p    on s.product_id   = p.product_id
+    left join stores st     on s.store_id     = st.store_id
+    left join prices pr     on s.price_id     = pr.price_id
+    left join promotions promo on s.promotion_id = promo.promotion_id
+
+)
+
+select * from enriched

--- a/data/dbt/models/intermediate/int_sales_enriched.sql
+++ b/data/dbt/models/intermediate/int_sales_enriched.sql
@@ -106,8 +106,8 @@ enriched as (
         promo.promotion_name,
         promo.discount_type,
         promo.discount_value,
-        promo.start_date as promotion_start_date,
-        promo.end_date as promotion_end_date
+        promo.promotion_start_date,
+        promo.promotion_end_date
 
     from sales s
 

--- a/data/dbt/models/intermediate/int_sales_enriched.sql
+++ b/data/dbt/models/intermediate/int_sales_enriched.sql
@@ -38,6 +38,8 @@ enriched as (
         s.unit_price,
         s.revenue,
         s.is_promo,
+
+        -- Pricing information captured on the transaction
         s.price_scope,
         s.price_type,
 
@@ -57,13 +59,46 @@ enriched as (
         st.city,
         st.region,
 
-        -- Price
+        -- Referenced price record
         pr.price_id,
         pr.price_amount,
         pr.currency_code,
-        pr.effective_from   as price_effective_from,
-        pr.effective_to     as price_effective_to,
+        pr.effective_from as price_effective_from,
+        pr.effective_to as price_effective_to,
         pr.price_status,
+
+        -- Price analysis fields
+        s.unit_price - pr.price_amount as price_difference,
+
+        case
+            when pr.price_amount is not null
+             and pr.price_amount != 0
+            then round(
+                ((s.unit_price - pr.price_amount) / pr.price_amount)::numeric,
+                4
+            )
+            else null
+        end as price_difference_rate,
+
+        case
+            when s.price_scope = 'STORE' then true
+            else false
+        end as is_store_specific_price,
+
+        case
+            when s.price_type = 'PROMO' then true
+            else false
+        end as is_promotional_price,
+
+        case
+            when cast(s.transaction_date as date) >= pr.effective_from
+             and (
+                pr.effective_to is null
+                or cast(s.transaction_date as date) <= pr.effective_to
+             )
+            then true
+            else false
+        end as is_price_temporally_valid,
 
         -- Promotion
         promo.promotion_id,
@@ -71,14 +106,22 @@ enriched as (
         promo.promotion_name,
         promo.discount_type,
         promo.discount_value,
-        promo.start_date    as promotion_start_date,
-        promo.end_date      as promotion_end_date
+        promo.start_date as promotion_start_date,
+        promo.end_date as promotion_end_date
 
     from sales s
-    left join products p    on s.product_id   = p.product_id
-    left join stores st     on s.store_id     = st.store_id
-    left join prices pr     on s.price_id     = pr.price_id
-    left join promotions promo on s.promotion_id = promo.promotion_id
+
+    left join products p
+        on s.product_id = p.product_id
+
+    left join stores st
+        on s.store_id = st.store_id
+
+    left join prices pr
+        on s.price_id = pr.price_id
+
+    left join promotions promo
+        on s.promotion_id = promo.promotion_id
 
 )
 

--- a/data/dbt/models/marts/obt_sales.sql
+++ b/data/dbt/models/marts/obt_sales.sql
@@ -34,6 +34,7 @@ obt as (
         pf.product_family_id,
         pf.product_family_code,
         pf.product_family_name,
+        pf.product_family_description,
 
         -- Store & Geography
         se.store_id,
@@ -74,6 +75,19 @@ obt as (
         se.promotion_start_date,
         se.promotion_end_date,
         se.is_promo,
+
+        case
+            when se.promotion_id is not null then true
+            else false
+        end as has_promotion,
+
+        case
+            when se.promotion_id is null then true
+            when cast(se.transaction_date as date) >= se.promotion_start_date
+             and cast(se.transaction_date as date) <= se.promotion_end_date
+            then true
+            else false
+        end as is_promotion_temporally_valid,
 
         -- Measures
         se.quantity,

--- a/data/dbt/models/marts/obt_sales.sql
+++ b/data/dbt/models/marts/obt_sales.sql
@@ -22,8 +22,8 @@ obt as (
         -- Transaction
         se.transaction_id,
         se.transaction_date,
-        cast(se.transaction_date as date)                as transaction_day,
-        date_trunc('month', se.transaction_date)::date   as transaction_month,
+        cast(se.transaction_date as date) as transaction_day,
+        date_trunc('month', se.transaction_date)::date as transaction_month,
 
         -- Product
         se.product_id,
@@ -45,15 +45,25 @@ obt as (
         c.country_code,
         c.country_name,
 
-        -- Price
+        -- Price reference
         se.price_id,
         se.price_amount,
         se.currency_code,
         se.price_effective_from,
         se.price_effective_to,
         se.price_status,
+
+        -- Pricing classification
         se.price_scope,
         se.price_type,
+        se.is_store_specific_price,
+        se.is_promotional_price,
+        se.is_price_temporally_valid,
+
+        -- Price performance
+        se.unit_price,
+        se.price_difference,
+        se.price_difference_rate,
 
         -- Promotion
         se.promotion_id,
@@ -67,12 +77,15 @@ obt as (
 
         -- Measures
         se.quantity,
-        se.unit_price,
         se.revenue
 
     from sales_enriched se
-    left join product_families pf on se.product_family_id = pf.product_family_id
-    left join countries c         on se.country_id        = c.country_id
+
+    left join product_families pf
+        on se.product_family_id = pf.product_family_id
+
+    left join countries c
+        on se.country_id = c.country_id
 
 )
 

--- a/data/dbt/models/marts/obt_sales.sql
+++ b/data/dbt/models/marts/obt_sales.sql
@@ -1,0 +1,79 @@
+with sales_enriched as (
+
+    select * from {{ ref('int_sales_enriched') }}
+
+),
+
+product_families as (
+
+    select * from {{ ref('stg_product_family') }}
+
+),
+
+countries as (
+
+    select * from {{ ref('stg_country') }}
+
+),
+
+obt as (
+
+    select
+        -- Transaction
+        se.transaction_id,
+        se.transaction_date,
+        cast(se.transaction_date as date)                as transaction_day,
+        date_trunc('month', se.transaction_date)::date   as transaction_month,
+
+        -- Product
+        se.product_id,
+        se.product_code,
+        se.product_name,
+        se.brand,
+        se.model,
+        pf.product_family_id,
+        pf.product_family_code,
+        pf.product_family_name,
+
+        -- Store & Geography
+        se.store_id,
+        se.store_code,
+        se.store_name,
+        se.city,
+        se.region,
+        c.country_id,
+        c.country_code,
+        c.country_name,
+
+        -- Price
+        se.price_id,
+        se.price_amount,
+        se.currency_code,
+        se.price_effective_from,
+        se.price_effective_to,
+        se.price_status,
+        se.price_scope,
+        se.price_type,
+
+        -- Promotion
+        se.promotion_id,
+        se.promotion_code,
+        se.promotion_name,
+        se.discount_type,
+        se.discount_value,
+        se.promotion_start_date,
+        se.promotion_end_date,
+        se.is_promo,
+
+        -- Measures
+        se.quantity,
+        se.unit_price,
+        se.revenue
+
+    from sales_enriched se
+    left join product_families pf on se.product_family_id = pf.product_family_id
+    left join countries c         on se.country_id        = c.country_id
+
+)
+
+select * from obt

--- a/data/dbt/models/marts/obt_sales.yml
+++ b/data/dbt/models/marts/obt_sales.yml
@@ -1,0 +1,74 @@
+version: 2
+
+models:
+  - name: obt_sales
+    description: "One Big Table — fully denormalized sales fact with all dimensions for analytics"
+    columns:
+      - name: transaction_id
+        description: "Primary key — unique sale transaction"
+        tests:
+          - unique
+          - not_null
+      - name: transaction_date
+        tests:
+          - not_null
+      - name: transaction_day
+        description: "Transaction date cast to date (no time)"
+        tests:
+          - not_null
+      - name: transaction_month
+        description: "First day of the transaction month"
+        tests:
+          - not_null
+      - name: product_id
+        tests:
+          - not_null
+      - name: product_code
+        tests:
+          - not_null
+      - name: product_name
+        tests:
+          - not_null
+      - name: store_id
+        tests:
+          - not_null
+      - name: store_code
+        tests:
+          - not_null
+      - name: store_name
+        tests:
+          - not_null
+      - name: country_code
+        tests:
+          - not_null
+      - name: country_name
+        tests:
+          - not_null
+      - name: price_scope
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['COUNTRY', 'STORE']
+      - name: price_type
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['STANDARD', 'PROMO']
+      - name: is_promo
+        tests:
+          - not_null
+      - name: quantity
+        tests:
+          - not_null
+      - name: unit_price
+        tests:
+          - not_null
+      - name: revenue
+        tests:
+          - not_null
+      - name: price_id
+        tests:
+          - not_null
+      - name: currency_code
+        tests:
+          - not_null

--- a/data/dbt/models/marts/obt_sales.yml
+++ b/data/dbt/models/marts/obt_sales.yml
@@ -96,3 +96,5 @@ models:
       - name: currency_code
         tests:
           - not_null
+      - name: product_family_description
+        description: "Product family business description. Useful for documentation and dashboard context."

--- a/data/dbt/models/marts/obt_sales.yml
+++ b/data/dbt/models/marts/obt_sales.yml
@@ -54,6 +54,30 @@ models:
           - not_null
           - accepted_values:
               values: ['STANDARD', 'PROMO']
+      - name: is_store_specific_price
+        description: "True if the price is scoped to a specific store"
+        tests:
+          - not_null
+      - name: is_promotional_price
+        description: "True if the price type is PROMO"
+        tests:
+          - not_null
+      - name: is_price_temporally_valid
+        description: "True if the transaction date falls within the price effective period"
+        tests:
+          - not_null
+      - name: price_amount
+        description: "Reference price amount from the price table"
+        tests:
+          - not_null
+      - name: price_difference
+        description: "Difference between reference price and unit price paid"
+        tests:
+          - not_null
+      - name: price_difference_rate
+        description: "Percentage difference between reference price and unit price"
+        tests:
+          - not_null
       - name: is_promo
         tests:
           - not_null

--- a/data/dbt/models/staging/sources.yml
+++ b/data/dbt/models/staging/sources.yml
@@ -1,0 +1,13 @@
+version: 2
+
+sources:
+  - name: pct_core
+    schema: pct_core
+    tables:
+      - name: sales_transaction
+      - name: product
+      - name: product_family
+      - name: store
+      - name: country
+      - name: price
+      - name: promotion

--- a/data/dbt/models/staging/stg.yml
+++ b/data/dbt/models/staging/stg.yml
@@ -128,10 +128,10 @@ models:
       - name: discount_value
         tests:
           - not_null
-      - name: start_date
+      - name: promotion_start_date
         tests:
           - not_null
-      - name: end_date
+      - name: promotion_end_date
         tests:
           - not_null
 

--- a/data/dbt/models/staging/stg.yml
+++ b/data/dbt/models/staging/stg.yml
@@ -1,0 +1,168 @@
+version: 2
+
+models:
+  - name: stg_sales
+    description: "Staged sales transactions from pct_core.sales_transaction"
+    columns:
+      - name: transaction_id
+        description: "Primary key"
+        tests:
+          - unique
+          - not_null
+      - name: transaction_date
+        tests:
+          - not_null
+      - name: product_id
+        tests:
+          - not_null
+      - name: store_id
+        tests:
+          - not_null
+      - name: price_id
+        tests:
+          - not_null
+      - name: quantity
+        tests:
+          - not_null
+      - name: unit_price
+        tests:
+          - not_null
+      - name: revenue
+        tests:
+          - not_null
+      - name: is_promo
+        tests:
+          - not_null
+      - name: price_scope
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['COUNTRY', 'STORE']
+      - name: price_type
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['STANDARD', 'PROMO']
+
+  - name: stg_product
+    description: "Staged products from pct_core.product"
+    columns:
+      - name: product_id
+        description: "Primary key"
+        tests:
+          - unique
+          - not_null
+      - name: product_code
+        tests:
+          - unique
+          - not_null
+      - name: product_name
+        tests:
+          - not_null
+
+  - name: stg_store
+    description: "Staged stores from pct_core.store"
+    columns:
+      - name: store_id
+        description: "Primary key"
+        tests:
+          - unique
+          - not_null
+      - name: store_code
+        tests:
+          - unique
+          - not_null
+      - name: store_name
+        tests:
+          - not_null
+      - name: country_id
+        tests:
+          - not_null
+
+  - name: stg_price
+    description: "Staged prices from pct_core.price"
+    columns:
+      - name: price_id
+        description: "Primary key"
+        tests:
+          - unique
+          - not_null
+      - name: product_id
+        tests:
+          - not_null
+      - name: price_scope
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['COUNTRY', 'STORE']
+      - name: price_type
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['STANDARD', 'PROMO']
+      - name: price_amount
+        tests:
+          - not_null
+      - name: currency_code
+        tests:
+          - not_null
+
+  - name: stg_promotion
+    description: "Staged promotions from pct_core.promotion"
+    columns:
+      - name: promotion_id
+        description: "Primary key"
+        tests:
+          - unique
+          - not_null
+      - name: promotion_code
+        tests:
+          - unique
+          - not_null
+      - name: promotion_name
+        tests:
+          - not_null
+      - name: discount_type
+        tests:
+          - not_null
+      - name: discount_value
+        tests:
+          - not_null
+      - name: start_date
+        tests:
+          - not_null
+      - name: end_date
+        tests:
+          - not_null
+
+  - name: stg_product_family
+    description: "Staged product families from pct_core.product_family"
+    columns:
+      - name: product_family_id
+        description: "Primary key"
+        tests:
+          - unique
+          - not_null
+      - name: product_family_code
+        tests:
+          - unique
+          - not_null
+      - name: product_family_name
+        tests:
+          - not_null
+
+  - name: stg_country
+    description: "Staged countries from pct_core.country"
+    columns:
+      - name: country_id
+        description: "Primary key"
+        tests:
+          - unique
+          - not_null
+      - name: country_code
+        tests:
+          - unique
+          - not_null
+      - name: country_name
+        tests:
+          - not_null

--- a/data/dbt/models/staging/stg_country.sql
+++ b/data/dbt/models/staging/stg_country.sql
@@ -1,0 +1,18 @@
+with source as (
+
+    select * from {{ source('pct_core', 'country') }}
+
+),
+
+renamed as (
+
+    select
+        id   as country_id,
+        code as country_code,
+        name as country_name
+
+    from source
+
+)
+
+select * from renamed

--- a/data/dbt/models/staging/stg_price.sql
+++ b/data/dbt/models/staging/stg_price.sql
@@ -1,0 +1,30 @@
+with source as (
+
+    select * from {{ source('pct_core', 'price') }}
+
+),
+
+renamed as (
+
+    select
+        id              as price_id,
+        product_id,
+        price_scope,
+        country_id,
+        store_id,
+        price_type,
+        amount          as price_amount,
+        currency_code,
+        effective_from,
+        effective_to,
+        status          as price_status,
+        promotion_id,
+        reason,
+        created_by,
+        created_at
+
+    from source
+
+)
+
+select * from renamed

--- a/data/dbt/models/staging/stg_product.sql
+++ b/data/dbt/models/staging/stg_product.sql
@@ -1,0 +1,23 @@
+with source as (
+
+    select * from {{ source('pct_core', 'product') }}
+
+),
+
+renamed as (
+
+    select
+        id          as product_id,
+        code        as product_code,
+        name        as product_name,
+        description as product_description,
+        brand,
+        model,
+        active      as is_active,
+        product_family_id
+
+    from source
+
+)
+
+select * from renamed

--- a/data/dbt/models/staging/stg_product_family.sql
+++ b/data/dbt/models/staging/stg_product_family.sql
@@ -1,0 +1,19 @@
+with source as (
+
+    select * from {{ source('pct_core', 'product_family') }}
+
+),
+
+renamed as (
+
+    select
+        id          as product_family_id,
+        code        as product_family_code,
+        name        as product_family_name,
+        description as product_family_description
+
+    from source
+
+)
+
+select * from renamed

--- a/data/dbt/models/staging/stg_promotion.sql
+++ b/data/dbt/models/staging/stg_promotion.sql
@@ -1,0 +1,28 @@
+with source as (
+
+    select * from {{ source('pct_core', 'promotion') }}
+
+),
+
+renamed as (
+
+    select
+        id              as promotion_id,
+        code            as promotion_code,
+        name            as promotion_name,
+        description     as promotion_description,
+        discount_type,
+        discount_value,
+        start_date,
+        end_date,
+        country_id,
+        store_id,
+        created_by,
+        created_at,
+        active          as is_active
+
+    from source
+
+)
+
+select * from renamed

--- a/data/dbt/models/staging/stg_promotion.sql
+++ b/data/dbt/models/staging/stg_promotion.sql
@@ -11,15 +11,20 @@ renamed as (
         code            as promotion_code,
         name            as promotion_name,
         description     as promotion_description,
+
         discount_type,
         discount_value,
-        start_date,
-        end_date,
-        country_id,
-        store_id,
-        created_by,
-        created_at,
-        active          as is_active
+
+        start_date      as promotion_start_date,
+        end_date        as promotion_end_date,
+
+        country_id      as promotion_country_id,
+        store_id        as promotion_store_id,
+
+        created_by      as promotion_created_by,
+        created_at      as promotion_created_at,
+
+        active          as promotion_is_active
 
     from source
 

--- a/data/dbt/models/staging/stg_sales.sql
+++ b/data/dbt/models/staging/stg_sales.sql
@@ -1,0 +1,27 @@
+with source as (
+
+    select * from {{ source('pct_core', 'sales_transaction') }}
+
+),
+
+renamed as (
+
+    select
+        transaction_id,
+        transaction_date,
+        product_id,
+        store_id,
+        price_id,
+        promotion_id,
+        quantity,
+        unit_price,
+        revenue,
+        is_promo,
+        price_scope,
+        price_type
+
+    from source
+
+)
+
+select * from renamed

--- a/data/dbt/models/staging/stg_store.sql
+++ b/data/dbt/models/staging/stg_store.sql
@@ -1,0 +1,22 @@
+with source as (
+
+    select * from {{ source('pct_core', 'store') }}
+
+),
+
+renamed as (
+
+    select
+        id           as store_id,
+        code         as store_code,
+        name         as store_name,
+        country_id,
+        city,
+        region,
+        opening_date
+
+    from source
+
+)
+
+select * from renamed


### PR DESCRIPTION
## Context

This PR implements the dbt analytical foundation for the Pricing Control Tower project.

The goal of this block is to create a reliable analytical base on top of the transactional `pct_core` schema. The central model introduced in this PR is `obt_sales`, a denormalized sales analytical table designed to support MVP dashboards and future KPI models.

This work follows the dbt layer structure:

- staging: source cleaning and column standardization
- intermediate: business joins and enrichment
- mart: final analytical model exposed in `pct_analytics`

---

## Objective

The objective of this PR is to build the first core analytical model for sales analysis.

This PR provides a unified sales table that enables analysis of:

- revenue
- sales volume
- country-level and store-level pricing
- standard and promotional prices
- promotion usage
- product family performance
- basic price and promotion consistency checks

The final model is designed to serve as the foundation for future KPI models related to sales performance, pricing performance and promotion analysis.

---

## Associated Tickets

- T54 — Create central analytical model `obt_sales`
- T55 — Enrich `obt_sales` with pricing attributes
- T56 — Enrich `obt_sales` with promotion and product family attributes

---

## Changes

### dbt staging layer

Added or updated staging models for the transactional sources:

- `stg_sales`
- `stg_product`
- `stg_product_family`
- `stg_store`
- `stg_country`
- `stg_price`
- `stg_promotion`

These models standardize column names and expose clean source data for downstream analytical models.

### dbt intermediate layer

Added or updated:

- `int_sales_enriched`

This model joins sales transactions with:

- product data
- store data
- price data
- promotion data

It also introduces analytical fields used by the final mart model, including:

- `price_difference`
- `price_difference_rate`
- `is_store_specific_price`
- `is_promotional_price`
- `is_price_temporally_valid`
- `has_promotion`
- `is_promotion_temporally_valid`

### dbt mart layer

Added or updated:

- `obt_sales`

The model is materialized in the `pct_analytics` schema and provides one analytical row per sales transaction.

### Business grain

The grain of `obt_sales` is:

```text
One row = one sales transaction
````

The source of truth for the applied price is:

```text
sales_transaction.price_id
```

This means the model does not dynamically recalculate the applicable price. It enriches each sale with the price record already referenced by the transaction.

---

## Main Analytical Fields

`obt_sales` includes:

### Transaction fields

* `transaction_id`
* `transaction_date`
* `transaction_day`
* `transaction_month`

### Product fields

* `product_id`
* `product_code`
* `product_name`
* `brand`
* `model`
* `product_family_id`
* `product_family_code`
* `product_family_name`
* `product_family_description`

### Store and geography fields

* `store_id`
* `store_code`
* `store_name`
* `city`
* `region`
* `country_id`
* `country_code`
* `country_name`

### Pricing fields

* `price_id`
* `price_amount`
* `currency_code`
* `price_effective_from`
* `price_effective_to`
* `price_status`
* `price_scope`
* `price_type`
* `is_store_specific_price`
* `is_promotional_price`
* `is_price_temporally_valid`
* `unit_price`
* `price_difference`
* `price_difference_rate`

### Promotion fields

* `promotion_id`
* `promotion_code`
* `promotion_name`
* `promotion_description`
* `discount_type`
* `discount_value`
* `promotion_start_date`
* `promotion_end_date`
* `promotion_country_id`
* `promotion_store_id`
* `promotion_is_active`
* `has_promotion`
* `is_promotion_temporally_valid`
* `is_promo`

### Measures

* `quantity`
* `revenue`

---

## Business Rules Implemented

### Pricing

The model uses the price referenced by each transaction:

```text
sales_transaction.price_id = price.price_id
```

Country and store pricing are represented through:

* `price_scope = COUNTRY`
* `price_scope = STORE`

The model exposes whether the sale used a store-specific price through:

* `is_store_specific_price`

A temporal validity flag checks whether the transaction date is covered by the referenced price validity period:

* `is_price_temporally_valid`

Invalid records are not filtered out. They remain visible for analytical control.

### Promotion

Promotion fields are nullable for non-promotional sales.

A transaction is considered linked to a promotion when:

```text
promotion_id is not null
```

This is exposed through:

* `has_promotion`

The model also checks whether the transaction date is within the promotion period:

* `is_promotion_temporally_valid`

Non-promotional sales are considered valid for this field because they are not subject to a promotion period.

### Product family

Each sale is enriched with product family information to support business grouping and future KPI aggregation.

---

## Tests Performed

* [x] dbt run executed successfully
* [x] dbt build executed successfully
* [x] dbt tests executed successfully
* [x] Manual SQL validation performed
* [x] Business consistency checks performed

### Commands used

```bash
dbt build --select +obt_sales
```

Additional validation was performed directly in PostgreSQL on:

```text
pct_analytics.obt_sales
```

---

## Evidence / Results

### Price temporal validity

```sql
select
    is_price_temporally_valid,
    count(*) as sales_count
from pct_analytics.obt_sales
group by is_price_temporally_valid
order by is_price_temporally_valid;
```

Result:

```text
is_price_temporally_valid | sales_count
--------------------------+------------
true                      | 500
```

All 500 sales transactions are temporally valid against their referenced price.

---

### Country vs store price scope

```sql
select
    price_scope,
    count(*) as sales_count,
    sum(quantity) as total_quantity,
    sum(revenue) as total_revenue
from pct_analytics.obt_sales
group by price_scope
order by price_scope;
```

Result:

```text
price_scope | sales_count | total_quantity | total_revenue
------------+-------------+----------------+--------------
COUNTRY     | 395         | 1352           | 86569.40
STORE       | 105         | 371            | 13021.06
```

The model correctly represents both country-level and store-level prices.

---

### Standard vs promotional sales

```sql
select
    price_type,
    is_promo,
    count(*) as sales_count,
    sum(quantity) as total_quantity,
    sum(revenue) as total_revenue
from pct_analytics.obt_sales
group by price_type, is_promo
order by price_type, is_promo;
```

Result:

```text
price_type | is_promo | sales_count | total_quantity | total_revenue
-----------+----------+-------------+----------------+--------------
PROMO      | true     | 11          | 48             | 1028.11
STANDARD   | false    | 489         | 1675           | 98562.35
```

Promotional and standard sales are consistently represented.

---

### Price difference control

```sql
select
    price_difference,
    count(*) as sales_count
from pct_analytics.obt_sales
group by price_difference
order by sales_count desc
limit 20;
```

Result:

```text
price_difference | sales_count
-----------------+------------
0.00             | 500
```

All transactions currently have a paid unit price equal to the referenced price amount.

---

### Promotion consistency

```sql
select
    is_promo,
    has_promotion,
    count(*) as sales_count,
    sum(quantity) as total_quantity,
    sum(revenue) as total_revenue
from pct_analytics.obt_sales
group by is_promo, has_promotion
order by is_promo, has_promotion;
```

Result:

```text
is_promo | has_promotion | sales_count | total_quantity | total_revenue
---------+---------------+-------------+----------------+--------------
false    | false         | 489         | 1675           | 98562.35
true     | true          | 11          | 48             | 1028.11
```

There are no inconsistent cases between `is_promo` and `has_promotion`.

---

### Promotion temporal validity

```sql
select
    is_promotion_temporally_valid,
    count(*) as sales_count
from pct_analytics.obt_sales
group by is_promotion_temporally_valid
order by is_promotion_temporally_valid;
```

Result:

```text
is_promotion_temporally_valid | sales_count
------------------------------+------------
true                          | 500
```

All sales are consistent with their promotion context.

---

### Product family analysis

```sql
select
    product_family_code,
    product_family_name,
    count(*) as sales_count,
    sum(quantity) as total_quantity,
    sum(revenue) as total_revenue
from pct_analytics.obt_sales
group by product_family_code, product_family_name
order by total_revenue desc;
```

Result:

```text
product_family_code | product_family_name | sales_count | total_quantity | total_revenue
--------------------+---------------------+-------------+----------------+--------------
RUN                 | Running             | 175         | 600            | 51772.80
FIT                 | Fitness             | 156         | 512            | 29732.05
CAMP                | Camping             | 161         | 582            | 17720.01
SPORT               | Sport               | 8           | 29             | 365.60
```

The model is ready for product family-based KPI analysis.

---

## Business Validation

The model is now suitable for MVP analytics, including:

* revenue analysis
* sales volume analysis
* price scope analysis
* promotional sales analysis
* product family analysis
* basic price consistency checks
* basic promotion consistency checks

The model is ready to support future KPI models, such as:

* sales performance KPIs
* promotion performance KPIs
* price performance KPIs
* revenue by product family
* revenue by store or country
* promo vs non-promo performance

---

## Limitations

* `obt_sales` does not yet compute aggregated KPIs.
* `obt_sales` does not calculate margin.
* `obt_sales` does not calculate promotion uplift.
* `obt_sales` does not compare promotion performance against a baseline period.
* The applicable price is not recalculated dynamically. The model uses `sales_transaction.price_id` as the applied price source of truth.
* Invalid pricing or promotion records are not filtered out. They are exposed through validation flags.
* Promotion fields remain nullable for non-promotional sales.

These limitations are intentional for the MVP and will be handled in future analytical models.

---

## Impacts

* [ ] Backend
* [ ] Frontend
* [ ] Database
* [x] Data pipeline
* [ ] CI/CD
* [x] Documentation

### Impact details

This PR impacts the dbt analytical layer only.

It introduces the first central mart model in `pct_analytics`, which will be used as the base for upcoming KPI models and dashboards.

No transactional database schema change is introduced.

---

## Review Notes

Please pay special attention to:

* the grain of `obt_sales`
* the use of `sales_transaction.price_id` as the applied price source of truth
* the distinction between `unit_price` and `price_amount`
* the handling of nullable promotion fields
* the validation flags for pricing and promotion temporal consistency
* the staging → intermediate → mart dbt structure

---

## Checklist

* [x] dbt staging models created or updated
* [x] intermediate sales enrichment model created or updated
* [x] mart model `obt_sales` created in `pct_analytics`
* [x] model grain documented
* [x] pricing attributes added
* [x] promotion attributes added
* [x] product family attributes added
* [x] dbt tests added
* [x] dbt build completed successfully
* [x] manual SQL validation completed
* [x] business validation completed

````
