### PR TITLE
Develop

### DIFF
--- a/data/dbt/models/marts/kpi_price_performance.sql
+++ b/data/dbt/models/marts/kpi_price_performance.sql
@@ -22,20 +22,39 @@ date_bounds as (
 
 ),
 
+period_bounds as (
+
+    select
+        max_transaction_date,
+        max_transaction_date - interval '30 days' as current_period_start_date,
+        max_transaction_date as current_period_end_date,
+        max_transaction_date - interval '60 days' as previous_period_start_date,
+        max_transaction_date - interval '30 days' as previous_period_end_date,
+        30 as analysis_period_days
+    from date_bounds
+
+),
+
 periodized_sales as (
 
     select
         s.*,
+        p.analysis_period_days,
+        p.current_period_start_date,
+        p.current_period_end_date,
+        p.previous_period_start_date,
+        p.previous_period_end_date,
         case
-            when s.transaction_date > d.max_transaction_date - interval '30 days'
+            when s.transaction_date > p.current_period_start_date
+             and s.transaction_date <= p.current_period_end_date
                 then 'current_period'
-            when s.transaction_date > d.max_transaction_date - interval '60 days'
-             and s.transaction_date <= d.max_transaction_date - interval '30 days'
+            when s.transaction_date > p.previous_period_start_date
+             and s.transaction_date <= p.previous_period_end_date
                 then 'previous_period'
             else 'out_of_scope'
         end as analysis_period
     from sales s
-    cross join date_bounds d
+    cross join period_bounds p
 
 ),
 
@@ -45,6 +64,12 @@ aggregated as (
         country_id,
         store_id,
         product_id,
+
+        max(analysis_period_days) as analysis_period_days,
+        max(current_period_start_date)::date as current_period_start_date,
+        max(current_period_end_date)::date as current_period_end_date,
+        max(previous_period_start_date)::date as previous_period_start_date,
+        max(previous_period_end_date)::date as previous_period_end_date,
 
         sum(case when analysis_period = 'current_period' then revenue else 0 end) as current_revenue,
         sum(case when analysis_period = 'previous_period' then revenue else 0 end) as previous_revenue,
@@ -68,70 +93,119 @@ country_benchmark as (
     select
         country_id,
         product_id,
-        sum(revenue) / nullif(sum(quantity), 0) as country_avg_selling_price
+
+        sum(case when analysis_period = 'current_period' then revenue else 0 end) as country_current_revenue,
+        sum(case when analysis_period = 'current_period' then quantity else 0 end) as country_current_quantity,
+
+        count(distinct case when analysis_period = 'current_period' then store_id end) as country_store_count,
+
+        sum(case when analysis_period = 'current_period' then revenue else 0 end)
+            / nullif(sum(case when analysis_period = 'current_period' then quantity else 0 end), 0)
+            as country_avg_selling_price
+
     from periodized_sales
     where analysis_period = 'current_period'
     group by
         country_id,
         product_id
 
+),
+
+final as (
+
+    select
+        a.country_id,
+        a.store_id,
+        a.product_id,
+
+        a.analysis_period_days,
+        a.current_period_start_date,
+        a.current_period_end_date,
+        a.previous_period_start_date,
+        a.previous_period_end_date,
+
+        a.current_revenue,
+        a.previous_revenue,
+
+        case
+            when a.previous_revenue = 0 then null
+            else round(((a.current_revenue - a.previous_revenue) / a.previous_revenue) * 100, 2)
+        end as revenue_change_pct,
+
+        a.current_quantity,
+        a.previous_quantity,
+
+        case
+            when a.previous_quantity = 0 then null
+            else round(((a.current_quantity - a.previous_quantity)::numeric / a.previous_quantity) * 100, 2)
+        end as quantity_change_pct,
+
+        round(a.current_revenue / nullif(a.current_quantity, 0), 2) as current_avg_selling_price,
+        round(a.previous_revenue / nullif(a.previous_quantity, 0), 2) as previous_avg_selling_price,
+
+        case
+            when a.previous_quantity = 0 or a.previous_revenue = 0 then null
+            else round(
+                (
+                    ((a.current_revenue / nullif(a.current_quantity, 0))
+                    - (a.previous_revenue / nullif(a.previous_quantity, 0)))
+                    / nullif((a.previous_revenue / nullif(a.previous_quantity, 0)), 0)
+                ) * 100,
+                2
+            )
+        end as avg_price_change_pct,
+
+        cb.country_current_revenue,
+        cb.country_current_quantity,
+        cb.country_store_count,
+
+        round(cb.country_avg_selling_price, 2) as country_avg_selling_price,
+
+        case
+            when cb.country_avg_selling_price = 0 then null
+            else round(
+                (
+                    (a.current_revenue / nullif(a.current_quantity, 0))
+                    - cb.country_avg_selling_price
+                ) / cb.country_avg_selling_price * 100,
+                2
+            )
+        end as price_vs_country_benchmark_pct,
+
+        case
+            when a.current_revenue = 0 then null
+            else round((a.current_promo_revenue / a.current_revenue) * 100, 2)
+        end as current_promo_revenue_share
+
+    from aggregated a
+    left join country_benchmark cb
+        on a.country_id = cb.country_id
+       and a.product_id = cb.product_id
+
 )
 
 select
-    a.country_id,
-    a.store_id,
-    a.product_id,
-
-    a.current_revenue,
-    a.previous_revenue,
+    *,
 
     case
-        when a.previous_revenue = 0 then null
-        else round(((a.current_revenue - a.previous_revenue) / a.previous_revenue) * 100, 2)
-    end as revenue_change_pct,
-
-    a.current_quantity,
-    a.previous_quantity,
-
-    case
-        when a.previous_quantity = 0 then null
-        else round(((a.current_quantity - a.previous_quantity)::numeric / a.previous_quantity) * 100, 2)
-    end as quantity_change_pct,
-
-    round(a.current_revenue / nullif(a.current_quantity, 0), 2) as current_avg_selling_price,
-    round(a.previous_revenue / nullif(a.previous_quantity, 0), 2) as previous_avg_selling_price,
+        when previous_revenue = 0 and current_revenue > 0 then 'NEW_ACTIVITY'
+        when revenue_change_pct >= 20 then 'STRONG_GROWTH'
+        when revenue_change_pct <= -20 then 'STRONG_DECLINE'
+        when revenue_change_pct between -20 and 20 then 'STABLE'
+        else 'NOT_COMPARABLE'
+    end as performance_flag,
 
     case
-        when a.previous_quantity = 0 or a.previous_revenue = 0 then null
-        else round(
-            (
-                ((a.current_revenue / nullif(a.current_quantity, 0))
-                - (a.previous_revenue / nullif(a.previous_quantity, 0)))
-                / nullif((a.previous_revenue / nullif(a.previous_quantity, 0)), 0)
-            ) * 100,
-            2
-        )
-    end as avg_price_change_pct,
+        when current_avg_selling_price is null
+        or country_avg_selling_price is null
+            then 'NOT_COMPARABLE'
+        when round(current_avg_selling_price, 2) = round(country_avg_selling_price, 2)
+            then 'ALIGNED_WITH_COUNTRY_BENCHMARK'
+        when round(current_avg_selling_price, 2) > round(country_avg_selling_price, 2)
+            then 'ABOVE_COUNTRY_BENCHMARK'
+        when round(current_avg_selling_price, 2) < round(country_avg_selling_price, 2)
+            then 'BELOW_COUNTRY_BENCHMARK'
+        else 'NOT_COMPARABLE'
+    end as benchmark_flag
 
-    round(cb.country_avg_selling_price, 2) as country_avg_selling_price,
-
-    case
-        when cb.country_avg_selling_price = 0 then null
-        else round(
-            (
-                (a.current_revenue / nullif(a.current_quantity, 0))
-                - cb.country_avg_selling_price
-            ) / cb.country_avg_selling_price * 100,
-            2
-        )
-    end as price_vs_country_benchmark_pct,
-
-    case
-        when a.current_revenue = 0 then null
-        else round((a.current_promo_revenue / a.current_revenue) * 100, 2)
-    end as current_promo_revenue_share
-
-from aggregated a
-left join country_benchmark cb
-    on a.country_id = cb.country_id
-   and a.product_id = cb.product_id
+from final

--- a/data/dbt/models/marts/kpi_price_performance.sql
+++ b/data/dbt/models/marts/kpi_price_performance.sql
@@ -1,0 +1,137 @@
+with sales as (
+
+    select
+        transaction_date::date as transaction_date,
+        country_id,
+        store_id,
+        product_id,
+        quantity,
+        revenue,
+        is_promo
+    from {{ ref('obt_sales') }}
+    where quantity > 0
+      and revenue > 0
+
+),
+
+date_bounds as (
+
+    select
+        max(transaction_date) as max_transaction_date
+    from sales
+
+),
+
+periodized_sales as (
+
+    select
+        s.*,
+        case
+            when s.transaction_date > d.max_transaction_date - interval '30 days'
+                then 'current_period'
+            when s.transaction_date > d.max_transaction_date - interval '60 days'
+             and s.transaction_date <= d.max_transaction_date - interval '30 days'
+                then 'previous_period'
+            else 'out_of_scope'
+        end as analysis_period
+    from sales s
+    cross join date_bounds d
+
+),
+
+aggregated as (
+
+    select
+        country_id,
+        store_id,
+        product_id,
+
+        sum(case when analysis_period = 'current_period' then revenue else 0 end) as current_revenue,
+        sum(case when analysis_period = 'previous_period' then revenue else 0 end) as previous_revenue,
+
+        sum(case when analysis_period = 'current_period' then quantity else 0 end) as current_quantity,
+        sum(case when analysis_period = 'previous_period' then quantity else 0 end) as previous_quantity,
+
+        sum(case when analysis_period = 'current_period' and is_promo then revenue else 0 end) as current_promo_revenue
+
+    from periodized_sales
+    where analysis_period in ('current_period', 'previous_period')
+    group by
+        country_id,
+        store_id,
+        product_id
+
+),
+
+country_benchmark as (
+
+    select
+        country_id,
+        product_id,
+        sum(revenue) / nullif(sum(quantity), 0) as country_avg_selling_price
+    from periodized_sales
+    where analysis_period = 'current_period'
+    group by
+        country_id,
+        product_id
+
+)
+
+select
+    a.country_id,
+    a.store_id,
+    a.product_id,
+
+    a.current_revenue,
+    a.previous_revenue,
+
+    case
+        when a.previous_revenue = 0 then null
+        else round(((a.current_revenue - a.previous_revenue) / a.previous_revenue) * 100, 2)
+    end as revenue_change_pct,
+
+    a.current_quantity,
+    a.previous_quantity,
+
+    case
+        when a.previous_quantity = 0 then null
+        else round(((a.current_quantity - a.previous_quantity)::numeric / a.previous_quantity) * 100, 2)
+    end as quantity_change_pct,
+
+    round(a.current_revenue / nullif(a.current_quantity, 0), 2) as current_avg_selling_price,
+    round(a.previous_revenue / nullif(a.previous_quantity, 0), 2) as previous_avg_selling_price,
+
+    case
+        when a.previous_quantity = 0 or a.previous_revenue = 0 then null
+        else round(
+            (
+                ((a.current_revenue / nullif(a.current_quantity, 0))
+                - (a.previous_revenue / nullif(a.previous_quantity, 0)))
+                / nullif((a.previous_revenue / nullif(a.previous_quantity, 0)), 0)
+            ) * 100,
+            2
+        )
+    end as avg_price_change_pct,
+
+    round(cb.country_avg_selling_price, 2) as country_avg_selling_price,
+
+    case
+        when cb.country_avg_selling_price = 0 then null
+        else round(
+            (
+                (a.current_revenue / nullif(a.current_quantity, 0))
+                - cb.country_avg_selling_price
+            ) / cb.country_avg_selling_price * 100,
+            2
+        )
+    end as price_vs_country_benchmark_pct,
+
+    case
+        when a.current_revenue = 0 then null
+        else round((a.current_promo_revenue / a.current_revenue) * 100, 2)
+    end as current_promo_revenue_share
+
+from aggregated a
+left join country_benchmark cb
+    on a.country_id = cb.country_id
+   and a.product_id = cb.product_id

--- a/data/dbt/models/marts/kpi_price_performance.yml
+++ b/data/dbt/models/marts/kpi_price_performance.yml
@@ -1,0 +1,50 @@
+version: 2
+
+models:
+  - name: kpi_price_performance
+    description: "KPI mart — price performance analysis with rolling 30-day period comparison, country benchmark and promo dependency"
+    columns:
+      - name: country_id
+        description: "Country identifier"
+        tests:
+          - not_null
+      - name: store_id
+        description: "Store identifier"
+        tests:
+          - not_null
+      - name: product_id
+        description: "Product identifier"
+        tests:
+          - not_null
+      - name: current_revenue
+        description: "Total revenue for the current 30-day period"
+        tests:
+          - not_null
+      - name: previous_revenue
+        description: "Total revenue for the previous 30-day period"
+        tests:
+          - not_null
+      - name: revenue_change_pct
+        description: "Percentage change in revenue between current and previous period. Null if no previous revenue"
+      - name: current_quantity
+        description: "Total quantity sold in the current 30-day period"
+        tests:
+          - not_null
+      - name: previous_quantity
+        description: "Total quantity sold in the previous 30-day period"
+        tests:
+          - not_null
+      - name: quantity_change_pct
+        description: "Percentage change in quantity between current and previous period. Null if no previous quantity"
+      - name: current_avg_selling_price
+        description: "Average selling price in the current period (revenue / quantity)"
+      - name: previous_avg_selling_price
+        description: "Average selling price in the previous period (revenue / quantity)"
+      - name: avg_price_change_pct
+        description: "Percentage change in average selling price between periods. Null if no previous data"
+      - name: country_avg_selling_price
+        description: "Country-level average selling price for the same product in the current period"
+      - name: price_vs_country_benchmark_pct
+        description: "Store price deviation vs country average (%). Positive = above benchmark, negative = below"
+      - name: current_promo_revenue_share
+        description: "Percentage of current period revenue generated under promotions. Null if no current revenue"

--- a/data/dbt/models/marts/kpi_price_performance.yml
+++ b/data/dbt/models/marts/kpi_price_performance.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: kpi_price_performance
-    description: "KPI mart — price performance analysis with rolling 30-day period comparison, country benchmark and promo dependency"
+    description: "KPI mart — price performance analysis with rolling 30-day period comparison, country benchmark, promo dependency and business flags"
     columns:
       - name: country_id
         description: "Country identifier"
@@ -14,6 +14,26 @@ models:
           - not_null
       - name: product_id
         description: "Product identifier"
+        tests:
+          - not_null
+      - name: analysis_period_days
+        description: "Number of days in each analysis period (default 30)"
+        tests:
+          - not_null
+      - name: current_period_start_date
+        description: "Start date of the current analysis period"
+        tests:
+          - not_null
+      - name: current_period_end_date
+        description: "End date of the current analysis period (= max transaction date)"
+        tests:
+          - not_null
+      - name: previous_period_start_date
+        description: "Start date of the previous analysis period"
+        tests:
+          - not_null
+      - name: previous_period_end_date
+        description: "End date of the previous analysis period"
         tests:
           - not_null
       - name: current_revenue
@@ -42,9 +62,27 @@ models:
         description: "Average selling price in the previous period (revenue / quantity)"
       - name: avg_price_change_pct
         description: "Percentage change in average selling price between periods. Null if no previous data"
+      - name: country_current_revenue
+        description: "Total revenue at country level for the product in the current period"
+      - name: country_current_quantity
+        description: "Total quantity at country level for the product in the current period"
+      - name: country_store_count
+        description: "Number of distinct stores selling the product in the country during the current period"
       - name: country_avg_selling_price
         description: "Country-level average selling price for the same product in the current period"
       - name: price_vs_country_benchmark_pct
         description: "Store price deviation vs country average (%). Positive = above benchmark, negative = below"
       - name: current_promo_revenue_share
         description: "Percentage of current period revenue generated under promotions. Null if no current revenue"
+      - name: performance_flag
+        description: "Business classification: NEW_ACTIVITY, STRONG_GROWTH, STRONG_DECLINE, STABLE, NOT_COMPARABLE"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['NEW_ACTIVITY', 'STRONG_GROWTH', 'STRONG_DECLINE', 'STABLE', 'NOT_COMPARABLE']
+      - name: benchmark_flag
+        description: "Position vs country benchmark: ABOVE_COUNTRY_BENCHMARK, BELOW_COUNTRY_BENCHMARK, ALIGNED_WITH_COUNTRY_BENCHMARK, NOT_COMPARABLE"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['ABOVE_COUNTRY_BENCHMARK', 'BELOW_COUNTRY_BENCHMARK', 'ALIGNED_WITH_COUNTRY_BENCHMARK', 'NOT_COMPARABLE']

--- a/docs/02_data_model/MLD_pct_analytics.md
+++ b/docs/02_data_model/MLD_pct_analytics.md
@@ -1,0 +1,163 @@
+# MLD — Schéma analytique `pct_analytics`
+
+## 1. Objectif
+
+Ce modèle logique de données décrit la structure du schéma `pct_analytics`, construit par dbt à partir des données transactionnelles du schéma `pct_core`.
+
+Il sert de référence pour :
+
+* comprendre la couche analytique du projet
+* documenter les modèles dbt (staging → intermediate → marts)
+* guider l'interprétation des KPI
+
+---
+
+## 2. Architecture des modèles dbt
+
+```
+sources (pct_core)
+    │
+    ├── stg_sales
+    ├── stg_product
+    ├── stg_product_family
+    ├── stg_store
+    ├── stg_country
+    ├── stg_price
+    └── stg_promotion
+            │
+            ▼
+    intermediate
+    └── int_sales_enriched
+            │
+            ▼
+    marts
+    ├── obt_sales
+    └── kpi_price_performance
+```
+
+---
+
+## 3. Couche Staging
+
+Les modèles staging extraient et renomment les colonnes depuis les tables source `pct_core`.
+
+| Modèle | Source | Description |
+|---|---|---|
+| `stg_sales` | `pct_core.sales_transaction` | Transactions de vente brutes |
+| `stg_product` | `pct_core.product` | Référentiel produit |
+| `stg_product_family` | `pct_core.product_family` | Familles de produits |
+| `stg_store` | `pct_core.store` | Référentiel magasin |
+| `stg_country` | `pct_core.country` | Référentiel pays |
+| `stg_price` | `pct_core.price` | Référentiel prix |
+| `stg_promotion` | `pct_core.promotion` | Référentiel promotions |
+
+---
+
+## 4. Couche Intermediate
+
+### 4.1 `int_sales_enriched`
+
+Jointure des ventes avec les dimensions produit, magasin, prix et promotion.
+
+| Champ | Description |
+|---|---|
+| `transaction_id` | PK — identifiant unique de la vente |
+| `transaction_date` | Date et heure de la transaction |
+| `product_id`, `product_code`, `product_name` | Dimensions produit |
+| `brand`, `model`, `product_family_id` | Attributs produit |
+| `store_id`, `store_code`, `store_name` | Dimensions magasin |
+| `country_id`, `city`, `region` | Dimensions géographiques |
+| `price_id`, `price_amount`, `currency_code` | Prix de référence |
+| `price_effective_from`, `price_effective_to` | Période de validité du prix |
+| `price_scope` | `COUNTRY` ou `STORE` |
+| `price_type` | `STANDARD` ou `PROMO` |
+| `is_store_specific_price` | Booléen — prix magasin spécifique |
+| `is_promotional_price` | Booléen — prix promotionnel |
+| `is_price_temporally_valid` | Booléen — validité temporelle du prix |
+| `price_difference` | Écart entre prix payé et prix de référence |
+| `price_difference_rate` | Taux d'écart prix payé vs référence |
+| `promotion_id`, `promotion_code`, `promotion_name` | Dimensions promotion |
+| `discount_type`, `discount_value` | Type et valeur de remise |
+| `promotion_start_date`, `promotion_end_date` | Période promotion |
+| `quantity`, `unit_price`, `revenue` | Mesures transactionnelles |
+| `is_promo` | Booléen — transaction liée à une promo |
+
+---
+
+## 5. Couche Marts
+
+### 5.1 `obt_sales` — One Big Table
+
+Table analytique centrale dénormalisée. Grain : **1 ligne = 1 transaction de vente**.
+
+Contient toutes les dimensions (produit, famille, magasin, pays, prix, promotion) et les mesures associées.
+
+#### Champs principaux
+
+| Catégorie | Champs |
+|---|---|
+| Transaction | `transaction_id`, `transaction_date`, `transaction_day`, `transaction_month` |
+| Produit | `product_id`, `product_code`, `product_name`, `brand`, `model` |
+| Famille | `product_family_id`, `product_family_code`, `product_family_name` |
+| Magasin | `store_id`, `store_code`, `store_name`, `city`, `region` |
+| Géographie | `country_id`, `country_code`, `country_name` |
+| Prix | `price_id`, `price_amount`, `currency_code`, `price_scope`, `price_type` |
+| Classification | `is_store_specific_price`, `is_promotional_price`, `is_price_temporally_valid` |
+| Performance prix | `unit_price`, `price_difference`, `price_difference_rate` |
+| Promotion | `promotion_id`, `promotion_code`, `has_promotion`, `is_promotion_temporally_valid` |
+| Mesures | `quantity`, `revenue` |
+| Flags | `is_promo` |
+
+---
+
+### 5.2 `kpi_price_performance` — KPI Performance Prix
+
+Modèle de KPI basé sur une comparaison glissante de 30 jours et un benchmark pays.
+
+#### Grain
+
+**1 ligne = 1 combinaison (country_id, store_id, product_id)**
+
+#### Périodes d'analyse
+
+| Période | Définition |
+|---|---|
+| Période courante | `max_date - 30 jours` → `max_date` |
+| Période précédente | `max_date - 60 jours` → `max_date - 30 jours` |
+
+#### Métriques calculées
+
+| Champ | Description |
+|---|---|
+| `current_revenue` / `previous_revenue` | CA sur chaque période |
+| `revenue_change_pct` | Variation de CA en % |
+| `current_quantity` / `previous_quantity` | Quantités vendues par période |
+| `quantity_change_pct` | Variation de quantité en % |
+| `current_avg_selling_price` | Prix moyen de vente (période courante) |
+| `previous_avg_selling_price` | Prix moyen de vente (période précédente) |
+| `avg_price_change_pct` | Variation du prix moyen en % |
+| `country_avg_selling_price` | Prix moyen pays pour le même produit |
+| `price_vs_country_benchmark_pct` | Écart du prix magasin vs benchmark pays (%) |
+| `current_promo_revenue_share` | Part du CA sous promotion (%) |
+
+#### Flags métier
+
+| Flag | Valeurs | Logique |
+|---|---|---|
+| `performance_flag` | `NEW_ACTIVITY`, `STRONG_GROWTH`, `STRONG_DECLINE`, `STABLE`, `NOT_COMPARABLE` | Basé sur `revenue_change_pct` (seuil ±20%) |
+| `benchmark_flag` | `ABOVE_COUNTRY_BENCHMARK`, `BELOW_COUNTRY_BENCHMARK`, `ALIGNED_WITH_COUNTRY_BENCHMARK`, `NOT_COMPARABLE` | Comparaison prix moyen magasin vs prix moyen pays |
+
+#### Règles des flags
+
+**performance_flag :**
+- `NEW_ACTIVITY` — pas de CA précédent mais CA courant > 0
+- `STRONG_GROWTH` — variation CA ≥ +20%
+- `STRONG_DECLINE` — variation CA ≤ -20%
+- `STABLE` — variation CA entre -20% et +20%
+- `NOT_COMPARABLE` — aucune condition remplie
+
+**benchmark_flag :**
+- `ALIGNED_WITH_COUNTRY_BENCHMARK` — prix moyen magasin = prix moyen pays (arrondi à 2 décimales)
+- `ABOVE_COUNTRY_BENCHMARK` — prix moyen magasin > prix moyen pays
+- `BELOW_COUNTRY_BENCHMARK` — prix moyen magasin < prix moyen pays
+- `NOT_COMPARABLE` — données insuffisantes (prix null)

--- a/docs/03_architecture/architecture_overview.md
+++ b/docs/03_architecture/architecture_overview.md
@@ -1,0 +1,107 @@
+# Architecture Overview — Pricing Control Tower
+
+## 1. Vue d'ensemble
+
+Le projet Pricing Control Tower est organisé en couches indépendantes communicant via des interfaces bien définies :
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   Frontend (Django)                  │
+│              Tailwind CSS — SSR — Pages              │
+└──────────────────────┬──────────────────────────────┘
+                       │ HTTP / REST
+┌──────────────────────▼──────────────────────────────┐
+│                  Backend (FastAPI)                   │
+│       API REST — SQLAlchemy — Alembic migrations    │
+└──────────────────────┬──────────────────────────────┘
+                       │ SQL
+┌──────────────────────▼──────────────────────────────┐
+│               PostgreSQL 16 (Docker)                 │
+│                                                     │
+│  ┌─────────────┐          ┌──────────────────┐     │
+│  │  pct_core   │          │  pct_analytics   │     │
+│  │ (transac.)  │──dbt────▶│ (vues analytiques)│    │
+│  └─────────────┘          └──────────────────┘     │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. Composants
+
+| Composant | Technologie | Rôle |
+|---|---|---|
+| **Backend** | FastAPI + SQLAlchemy | API REST, logique métier, accès données transactionnelles |
+| **Frontend** | Django + Tailwind CSS | Interface utilisateur, rendu serveur (SSR) |
+| **Base de données** | PostgreSQL 16 | Stockage transactionnel (`pct_core`) et analytique (`pct_analytics`) |
+| **Transformation** | dbt (dbt-postgres) | Pipeline de transformation : staging → intermediate → marts |
+| **Génération de données** | Python (scripts) | Simulation de ventes réalistes pour le MVP |
+| **Conteneurisation** | Docker Compose | Orchestration locale (PostgreSQL) |
+
+---
+
+## 3. Schémas de base de données
+
+### `pct_core` — Données transactionnelles
+
+Géré par Alembic (migrations versionnées). Contient :
+
+- `country`, `store` — Référentiel géographique
+- `product_family`, `product`, `product_image` — Référentiel produit
+- `price` — Prix (standard et promotionnel)
+- `promotion` — Promotions
+- `sales_transaction` — Transactions de vente
+- `user_account` — Utilisateurs
+
+### `pct_analytics` — Données analytiques
+
+Géré par dbt. Contient des vues matérialisées :
+
+- **Staging** : `stg_sales`, `stg_product`, `stg_store`, `stg_country`, `stg_price`, `stg_promotion`, `stg_product_family`
+- **Intermediate** : `int_sales_enriched`
+- **Marts** : `obt_sales`, `kpi_price_performance`
+
+---
+
+## 4. Organisation du code
+
+```
+princing-control-tower/
+├── backend/              # API FastAPI + migrations Alembic
+│   ├── app/              # Code applicatif (routes, modèles, schémas)
+│   ├── alembic/          # Migrations de schéma pct_core
+│   ├── tests/            # Tests unitaires et intégration
+│   └── docker-compose.yml
+├── data/                 # Couche data
+│   ├── dbt/              # Projet dbt (staging, intermediate, marts)
+│   ├── generated/        # Fichiers CSV générés
+│   └── generation/       # Scripts de génération de données
+├── docs/                 # Documentation complète
+│   ├── 01_functional/    # Cahier des charges
+│   ├── 02_data_model/    # MCD, MLD, MPD
+│   ├── 03_architecture/  # Architecture, flux, choix techniques
+│   ├── 04_agilite/       # Backlog, epics, user stories
+│   └── 05_runbook/       # Installation, déploiement, monitoring
+└── frontend/             # Application Django (à venir)
+```
+
+---
+
+## 5. Communication entre composants
+
+| Source | Destination | Protocole | Description |
+|---|---|---|---|
+| Frontend | Backend | HTTP REST | Consommation des endpoints API |
+| Backend | PostgreSQL | SQL (asyncpg) | CRUD sur `pct_core` |
+| dbt | PostgreSQL | SQL | Lecture `pct_core`, écriture `pct_analytics` |
+| Scripts génération | PostgreSQL | SQL (psycopg2) | Insertion des données simulées |
+
+---
+
+## 6. Principes d'architecture
+
+- **Séparation des responsabilités** : chaque composant a un rôle unique
+- **Couche analytique en lecture seule** : dbt ne modifie jamais `pct_core`
+- **Données simulées reproductibles** : seed fixe pour la génération
+- **Migrations versionnées** : Alembic pour toute modification de schéma
+- **API stateless** : pas de session côté serveur

--- a/docs/03_architecture/choix_techniques.md
+++ b/docs/03_architecture/choix_techniques.md
@@ -1,0 +1,90 @@
+# Choix Techniques — Pricing Control Tower
+
+## 1. Backend
+
+| Technologie | Version | Justification |
+|---|---|---|
+| **Python** | 3.11+ | Langage principal — écosystème data et IA mature |
+| **FastAPI** | 0.100+ | Framework API moderne, typage natif, documentation auto (OpenAPI) |
+| **SQLAlchemy** | 2.x | ORM robuste, support async, mapping déclaratif |
+| **Alembic** | 1.x | Migrations versionnées, intégration native SQLAlchemy |
+| **uv** | — | Gestionnaire de packages rapide, remplacement de pip |
+| **Pydantic** | 2.x | Validation des données, sérialisation, schémas API |
+
+---
+
+## 2. Base de données
+
+| Technologie | Version | Justification |
+|---|---|---|
+| **PostgreSQL** | 16 | SGBD relationnel performant, support JSON, CTE, window functions |
+| **Docker Compose** | — | Orchestration locale simple et reproductible |
+
+### Organisation des schémas
+
+| Schéma | Rôle | Gestion |
+|---|---|---|
+| `pct_core` | Données transactionnelles et référentiel | Alembic (migrations) |
+| `pct_analytics` | Vues analytiques et KPI | dbt (transformations) |
+
+---
+
+## 3. Data / Analytics
+
+| Technologie | Version | Justification |
+|---|---|---|
+| **dbt** (dbt-core + dbt-postgres) | 1.8+ | Transformation SQL versionnée, tests intégrés, documentation auto |
+| **Python (scripts)** | — | Génération de données simulées reproductibles |
+
+### Architecture dbt
+
+- **Staging** : extraction et renommage depuis les sources `pct_core`
+- **Intermediate** : enrichissement par jointures (ventes × dimensions)
+- **Marts** : tables dénormalisées (`obt_sales`) et KPI (`kpi_price_performance`)
+
+### Choix de modélisation analytique
+
+- **OBT (One Big Table)** : approche dénormalisée adaptée au volume MVP (~20k lignes)
+- **Périodisation glissante** : comparaison 30 jours vs 30 jours précédents (pas de calendrier fiscal)
+- **Benchmark pays** : prix moyen pondéré par volume au niveau country × product
+
+---
+
+## 4. Frontend
+
+| Technologie | Justification |
+|---|---|
+| **Django** | Framework full-stack Python, rendu serveur (SSR), admin intégré |
+| **Tailwind CSS** | Utility-first CSS, rapidité de développement, design responsive |
+
+---
+
+## 5. Infrastructure
+
+| Technologie | Justification |
+|---|---|
+| **Docker** | Conteneurisation pour la reproductibilité |
+| **Docker Compose** | Orchestration locale (PostgreSQL) |
+| **GCP Cloud Run** (cible) | Déploiement cloud serverless |
+
+---
+
+## 6. Qualité et Tests
+
+| Outil | Rôle |
+|---|---|
+| **pytest** | Tests unitaires et intégration backend |
+| **dbt test** | Tests de données (not_null, unique, accepted_values) |
+| **GitHub Actions** (cible) | CI/CD automatisée |
+
+---
+
+## 7. Décisions clés
+
+| Décision | Raison |
+|---|---|
+| PostgreSQL unique (core + analytics) | Simplicité MVP, pas de datawarehouse séparé nécessaire |
+| dbt en vues (pas de tables matérialisées) | Volume faible, rafraîchissement instantané |
+| Génération Python plutôt que Faker | Contrôle total de la distribution et reproductibilité (seed fixe) |
+| API stateless | Scalabilité, simplicité, pas de gestion de session |
+| Séparation backend/data/frontend | Indépendance des déploiements, responsabilités claires |

--- a/docs/03_architecture/data_flow.md
+++ b/docs/03_architecture/data_flow.md
@@ -1,0 +1,145 @@
+# Data Flow — Pricing Control Tower
+
+## 1. Vue d'ensemble du flux de données
+
+```
+┌───────────────────┐     ┌──────────────────┐     ┌─────────────────────┐
+│  Scripts Python   │────▶│   pct_core       │────▶│   pct_analytics     │
+│  (génération)     │     │   (PostgreSQL)   │     │   (vues dbt)        │
+└───────────────────┘     └──────────────────┘     └─────────────────────┘
+        │                         │                         │
+   seed_reference_data.py         │                    obt_sales
+   generate_sales_dataset.py      │                    kpi_price_performance
+   load_sales_transactions.py     │                         │
+                                  │                         ▼
+                           ┌──────▼──────┐          ┌──────────────┐
+                           │  FastAPI    │          │  Frontend    │
+                           │  (Backend)  │◀─────────│  (Django)    │
+                           └─────────────┘          └──────────────┘
+```
+
+---
+
+## 2. Flux d'ingestion (données → pct_core)
+
+### Étape 1 : Seed des données de référence
+
+**Script** : `data/generation/seed_reference_data.py`
+
+Insère les données de référence dans `pct_core` :
+- Pays (country)
+- Magasins (store)
+- Familles de produits (product_family)
+- Produits (product)
+- Prix standards et promotionnels (price)
+- Promotions (promotion)
+
+### Étape 2 : Génération du dataset de ventes
+
+**Script** : `data/generation/generate_sales_dataset.py`
+
+Génère un fichier CSV (`data/generated/sales_transactions.csv`) contenant ~20 000 transactions simulées sur 6 mois.
+
+Règles de génération :
+- Distribution non uniforme des quantités (variabilité produit + magasin + effet promo)
+- Saisonnalité simple
+- Cohérence avec les prix et promotions actifs à chaque date
+
+### Étape 3 : Chargement en base
+
+**Script** : `data/generation/load_sales_transactions.py`
+
+Charge le CSV dans la table `pct_core.sales_transaction`.
+
+---
+
+## 3. Flux de transformation (pct_core → pct_analytics via dbt)
+
+### Pipeline dbt
+
+```
+pct_core (source)
+    │
+    ▼
+STAGING (renommage, typage)
+    stg_sales, stg_product, stg_product_family,
+    stg_store, stg_country, stg_price, stg_promotion
+    │
+    ▼
+INTERMEDIATE (enrichissement, jointures)
+    int_sales_enriched
+    │
+    ▼
+MARTS (agrégation, KPI)
+    obt_sales              → Table dénormalisée complète
+    kpi_price_performance  → KPI glissant 30j + benchmark pays
+```
+
+### Détail des transformations
+
+| Couche | Modèle | Transformation |
+|---|---|---|
+| Staging | `stg_*` | Sélection des colonnes, renommage, typage |
+| Intermediate | `int_sales_enriched` | Jointure ventes × produit × magasin × prix × promotion. Calcul `price_difference`, `price_difference_rate`, flags booléens |
+| Mart | `obt_sales` | Ajout familles, pays, classification temporelle promotion |
+| Mart | `kpi_price_performance` | Périodisation 30j, agrégation par (country, store, product), benchmark pays, flags métier |
+
+---
+
+## 4. Flux de consommation (pct_analytics → API → Frontend)
+
+### Backend (FastAPI)
+
+L'API expose les données de `pct_core` via des endpoints REST :
+- `GET /products` — Référentiel produits
+- `GET /prices` — Prix standards et promotionnels
+- `GET /promotions` — Promotions actives et historiques
+
+Les KPI issus de `pct_analytics` sont consommables via des endpoints dédiés (évolution).
+
+### Frontend (Django)
+
+Consomme l'API REST pour afficher :
+- Tableaux de bord
+- Listes de produits et prix
+- Indicateurs de performance
+
+---
+
+## 5. Dépendances du flux
+
+| Étape | Prérequis |
+|---|---|
+| Seed référentiel | PostgreSQL opérationnel, schéma `pct_core` créé |
+| Génération ventes | Référentiel inséré (produits, magasins, prix, promos) |
+| Chargement ventes | CSV généré |
+| dbt run | Données présentes dans `pct_core`, schéma `pct_analytics` créé |
+| API | PostgreSQL accessible |
+| Frontend | API accessible |
+
+---
+
+## 6. Commandes d'exécution
+
+```bash
+# 1. Démarrer PostgreSQL
+cd backend && docker compose up -d
+
+# 2. Appliquer les migrations
+alembic upgrade head
+
+# 3. Seed des données de référence
+python data/generation/seed_reference_data.py
+
+# 4. Générer les ventes
+python data/generation/generate_sales_dataset.py
+
+# 5. Charger les ventes
+python data/generation/load_sales_transactions.py
+
+# 6. Exécuter dbt
+cd data/dbt && dbt run
+
+# 7. Lancer l'API
+cd backend && uvicorn app.main:app --reload
+```

--- a/docs/05_runbook/run_local.md
+++ b/docs/05_runbook/run_local.md
@@ -1,0 +1,157 @@
+# Run Local — Guide d'exécution locale
+
+## Prérequis
+
+- Python 3.11+
+- Docker & Docker Compose
+- uv (gestionnaire de packages Python)
+- Git
+
+---
+
+## 1. Cloner le projet
+
+```bash
+git clone <repo_url>
+cd princing-control-tower
+```
+
+---
+
+## 2. Démarrer PostgreSQL
+
+```bash
+cd backend
+docker compose up -d
+```
+
+Vérification :
+
+```bash
+docker compose exec postgres psql -U pct_user -d pct -c "SELECT 1;"
+```
+
+---
+
+## 3. Configurer l'environnement Python
+
+```bash
+cd backend
+uv venv .venv
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+```
+
+---
+
+## 4. Variables d'environnement
+
+Créer un fichier `backend/.env` :
+
+```env
+POSTGRES_USER=pct_user
+POSTGRES_PASSWORD=pct_password
+POSTGRES_DB=pct
+DATABASE_URL=postgresql://pct_user:pct_password@localhost:5432/pct
+```
+
+---
+
+## 5. Appliquer les migrations
+
+```bash
+cd backend
+alembic upgrade head
+```
+
+Cela crée le schéma `pct_core` et toutes les tables (country, store, product, price, promotion, sales_transaction, etc.).
+
+---
+
+## 6. Charger les données de référence
+
+```bash
+python data/generation/seed_reference_data.py
+```
+
+Insère les pays, magasins, familles, produits, prix et promotions.
+
+---
+
+## 7. Générer et charger les ventes
+
+```bash
+# Génération du CSV
+python data/generation/generate_sales_dataset.py
+
+# Chargement en base
+python data/generation/load_sales_transactions.py
+```
+
+Le fichier généré est `data/generated/sales_transactions.csv` (~20 000 lignes).
+
+---
+
+## 8. Exécuter dbt
+
+```bash
+cd data/dbt
+dbt run
+```
+
+Cela crée les vues dans le schéma `pct_analytics` :
+- `stg_*` (staging)
+- `int_sales_enriched` (intermediate)
+- `obt_sales` (mart — OBT)
+- `kpi_price_performance` (mart — KPI)
+
+### Tests dbt
+
+```bash
+dbt test
+```
+
+---
+
+## 9. Lancer l'API
+
+```bash
+cd backend
+source .venv/bin/activate
+uvicorn app.main:app --reload --port 8000
+```
+
+L'API est accessible sur `http://localhost:8000`.
+
+Documentation interactive : `http://localhost:8000/docs`
+
+---
+
+## 10. Vérifications rapides
+
+```bash
+# Santé de l'API
+curl http://localhost:8000/health
+
+# Liste des produits
+curl http://localhost:8000/products
+
+# KPI depuis psql
+docker compose exec postgres psql -U pct_user -d pct \
+  -c "SELECT * FROM pct_analytics.kpi_price_performance LIMIT 5;"
+```
+
+---
+
+## Résumé des commandes
+
+| Étape | Commande |
+|---|---|
+| PostgreSQL | `cd backend && docker compose up -d` |
+| Migrations | `cd backend && alembic upgrade head` |
+| Seed référentiel | `python data/generation/seed_reference_data.py` |
+| Génération ventes | `python data/generation/generate_sales_dataset.py` |
+| Chargement ventes | `python data/generation/load_sales_transactions.py` |
+| dbt | `cd data/dbt && dbt run` |
+| Tests dbt | `cd data/dbt && dbt test` |
+| API | `cd backend && uvicorn app.main:app --reload` |


### PR DESCRIPTION
## Context

This PR introduces the first MVP pricing performance KPI model for the Pricing Control Tower analytics layer.

The source model `obt_sales` is already available and contains consolidated sales data enriched with pricing and promotion information.

This model is designed to prepare pricing performance indicators that can later be exposed through the API and consumed by the web application.

---

## Objective

Create and enrich the `kpi_price_performance` dbt model to support business analysis of pricing performance.

The model provides:

- current vs previous period analysis,
- revenue and volume performance indicators,
- average selling price analysis,
- country-level benchmark comparison,
- business flags for performance interpretation,
- business flags for country benchmark alignment.

---

## Associated Tickets

- T57 — Create pricing performance KPI model
- T58 — Enrich price performance KPI with before/after analysis and country benchmark

---

## Changes

### Added `kpi_price_performance` model

Created the analytics model:

```text
pct_analytics.kpi_price_performance
````

The model is built from:

```text
pct_analytics.obt_sales
```

The model grain is:

```text
country_id + store_id + product_id
```

### Added before / after analysis

The model now compares two rolling 30-day periods based on the latest available transaction date in `obt_sales`.

* Current period: latest 30 available days
* Previous period: 30 days before the current period

The following period metadata columns were added:

* `analysis_period_days`
* `current_period_start_date`
* `current_period_end_date`
* `previous_period_start_date`
* `previous_period_end_date`

### Added pricing performance indicators

The following KPI columns were added:

* `current_revenue`
* `previous_revenue`
* `revenue_change_pct`
* `current_quantity`
* `previous_quantity`
* `quantity_change_pct`
* `current_avg_selling_price`
* `previous_avg_selling_price`
* `avg_price_change_pct`
* `current_promo_revenue_share`

### Added country benchmark indicators

The model now computes country-level benchmark values for each product.

The following columns were added:

* `country_current_revenue`
* `country_current_quantity`
* `country_store_count`
* `country_avg_selling_price`
* `price_vs_country_benchmark_pct`

### Added business interpretation flags

The model now includes:

```text
performance_flag
```

Possible values:

* `NEW_ACTIVITY`
* `STRONG_GROWTH`
* `STRONG_DECLINE`
* `STABLE`
* `NOT_COMPARABLE`

The model also includes:

```text
benchmark_flag
```

Possible values:

* `ALIGNED_WITH_COUNTRY_BENCHMARK`
* `ABOVE_COUNTRY_BENCHMARK`
* `BELOW_COUNTRY_BENCHMARK`
* `NOT_COMPARABLE`

### Corrected benchmark business rule

The country benchmark logic was corrected to match the pricing business rule.

A store price is considered aligned with the country benchmark only when:

```text
current_avg_selling_price = country_avg_selling_price
```

Values are compared after rounding to 2 decimals.

The previous threshold-based logic was removed because it was not compliant with the business rule.

Previous logic:

```text
-10% to +10% = aligned
```

Corrected logic:

```text
equal = aligned
above = above country benchmark
below = below country benchmark
null = not comparable
```

---

## Business KPI Definitions

### Current revenue

Revenue generated during the latest 30 available days in `obt_sales`.

### Previous revenue

Revenue generated during the 30 days before the current period.

### Revenue change percentage

Measures revenue evolution between the current and previous periods.

Formula:

```text
(current_revenue - previous_revenue) / previous_revenue * 100
```

If `previous_revenue = 0`, the value is set to `null`.

### Current quantity

Quantity sold during the latest 30 available days.

### Previous quantity

Quantity sold during the previous 30-day period.

### Quantity change percentage

Measures volume evolution between the current and previous periods.

Formula:

```text
(current_quantity - previous_quantity) / previous_quantity * 100
```

If `previous_quantity = 0`, the value is set to `null`.

### Current average selling price

Average price paid by customers during the current period.

Formula:

```text
current_revenue / current_quantity
```

### Previous average selling price

Average price paid by customers during the previous period.

Formula:

```text
previous_revenue / previous_quantity
```

### Average selling price change percentage

Measures the evolution of the average selling price between the two periods.

### Country average selling price

Average selling price for the same product at country level during the current period.

Formula:

```text
country_current_revenue / country_current_quantity
```

### Price versus country benchmark percentage

Measures the percentage gap between the store average selling price and the country average selling price.

Formula:

```text
(current_avg_selling_price - country_avg_selling_price) / country_avg_selling_price * 100
```

### Current promotional revenue share

Share of current period revenue generated through promotional sales.

Formula:

```text
current_promo_revenue / current_revenue * 100
```

---

## Business Assumptions

The before / after analysis is based on two rolling 30-day periods using the latest available transaction date in `obt_sales`.

This is an MVP approach.

The comparison is period-based and does not yet represent a true before / after analysis based on an approved price change event.

A true event-based price change analysis will be introduced later when the price change workflow is available in the analytics layer.

Country benchmark is calculated at:

```text
country_id + product_id
```

Store performance is compared against the country average selling price for the same product.

Promotional sales are included in the average selling price because they reflect the actual paid price.

A row is marked as `NOT_COMPARABLE` when the model cannot calculate a current average selling price or a country benchmark.

---

## Known Limitations

* The before / after logic is period-based, not event-based.
* The model does not yet rely on a real price change request or applied price change date.
* Products with no previous sales cannot have a percentage evolution.
* Products with no current sales cannot be compared to the country benchmark.
* Low sales volumes may create unstable percentage variations.
* Promotional sales can lower the average selling price.
* Country benchmark may be weak when the product was sold in only one store.
* Stock availability is not included, so volume drops cannot always be interpreted as pricing issues.

---

## Tests Performed

* [x] dbt model executed successfully
* [x] Row count validated
* [x] Revenue reconciliation with `obt_sales` validated
* [x] Before / after logic validated on sample rows
* [x] Country benchmark flag distribution validated
* [x] Strict benchmark business rule corrected and validated
* [ ] Automated dbt tests added

---

## Validation Steps

### Run dbt model

```bash
dbt run --select kpi_price_performance
```

### Validate row count

```sql
select count(*)
from pct_analytics.kpi_price_performance;
```

Result:

```text
124
```

### Validate current revenue reconciliation with `obt_sales`

Source validation query:

```sql
with max_date as (
    select max(transaction_date::date) as max_transaction_date
    from pct_analytics.obt_sales
)
select
    sum(revenue) as expected_current_revenue
from pct_analytics.obt_sales, max_date
where transaction_date::date > max_transaction_date - interval '30 days';
```

Result:

```text
18865.01
```

KPI validation query:

```sql
select sum(current_revenue)
from pct_analytics.kpi_price_performance;
```

Result:

```text
18865.01
```

Validation result:

```text
PASSED — current_revenue matches obt_sales
```

### Validate period metadata

Sample results confirm:

```text
analysis_period_days = 30
current_period_start_date = 2025-05-31
current_period_end_date = 2025-06-30
previous_period_start_date = 2025-05-01
previous_period_end_date = 2025-05-31
```

### Validate benchmark flag distribution

```sql
select
    benchmark_flag,
    count(*) as rows_count
from pct_analytics.kpi_price_performance
group by benchmark_flag
order by rows_count desc;
```

Result:

```text
ALIGNED_WITH_COUNTRY_BENCHMARK | 55
NOT_COMPARABLE                 | 53
BELOW_COUNTRY_BENCHMARK        | 9
ABOVE_COUNTRY_BENCHMARK        | 7
```

This confirms that the strict benchmark rule is now correctly applied.

### Validate strict alignment rule

Expected rule:

```text
ALIGNED_WITH_COUNTRY_BENCHMARK means current_avg_selling_price equals country_avg_selling_price after rounding to 2 decimals.
```

Recommended validation query:

```sql
select
    count(*) as invalid_aligned_rows
from pct_analytics.kpi_price_performance
where benchmark_flag = 'ALIGNED_WITH_COUNTRY_BENCHMARK'
  and round(current_avg_selling_price, 2) <> round(country_avg_selling_price, 2);
```

Expected result:

```text
0
```

### Validate above benchmark rule

```sql
select
    count(*) as invalid_above_rows
from pct_analytics.kpi_price_performance
where benchmark_flag = 'ABOVE_COUNTRY_BENCHMARK'
  and round(current_avg_selling_price, 2) <= round(country_avg_selling_price, 2);
```

Expected result:

```text
0
```

### Validate below benchmark rule

```sql
select
    count(*) as invalid_below_rows
from pct_analytics.kpi_price_performance
where benchmark_flag = 'BELOW_COUNTRY_BENCHMARK'
  and round(current_avg_selling_price, 2) >= round(country_avg_selling_price, 2);
```

Expected result:

```text
0
```

---

## Evidence / Results

### Row count

```text
pct_analytics.kpi_price_performance = 124 rows
```

### Revenue reconciliation

```text
expected_current_revenue from obt_sales = 18865.01
sum(current_revenue) from kpi_price_performance = 18865.01
```

### Benchmark distribution after business rule correction

```text
ALIGNED_WITH_COUNTRY_BENCHMARK = 55
NOT_COMPARABLE = 53
BELOW_COUNTRY_BENCHMARK = 9
ABOVE_COUNTRY_BENCHMARK = 7
```

### Business validation

The benchmark logic was corrected to match the pricing business rule: a store price is aligned with the country benchmark only when the store average selling price equals the country average selling price, rounded to two decimals.

After correction, the model identifies aligned, above-benchmark, below-benchmark and non-comparable rows.

---

## Impacts

* [ ] Backend
* [ ] Frontend
* [ ] Database
* [x] Data pipeline
* [ ] CI/CD
* [x] Documentation

---

## Review Notes

This model is intentionally MVP-oriented.

The current before / after analysis is based on rolling time periods and should be improved later when the price change request workflow is available in the analytics layer.

The country benchmark comparison now follows the strict pricing business rule:

```text
aligned = equal to country benchmark
above = greater than country benchmark
below = lower than country benchmark
```

No tolerance threshold is applied.

---

## Checklist

* [x] Model created
* [x] KPI calculations implemented
* [x] Before / after analysis added
* [x] Country benchmark added
* [x] Business benchmark rule corrected
* [x] Manual validation completed
* [x] Results reconciled with `obt_sales`
* [x] Known assumptions documented
* [ ] Automated dbt tests added

````