### PR TITLE
feat: implement price change workflow

### DIFF
--- a/backend/alembic/versions/ce9a2d7a81b5_add_rejection_fields_to_price_change_.py
+++ b/backend/alembic/versions/ce9a2d7a81b5_add_rejection_fields_to_price_change_.py
@@ -1,0 +1,76 @@
+"""add rejection fields to price_change_request
+
+Revision ID: ce9a2d7a81b5
+Revises: 63cb3004e2e5
+Create Date: 2026-05-06 10:11:45.416715
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ce9a2d7a81b5'
+down_revision: Union[str, Sequence[str], None] = '63cb3004e2e5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+
+def upgrade() -> None:
+    op.add_column(
+        "price_change_request",
+        sa.Column("rejection_reason", sa.Text(), nullable=True),
+        schema="pct_core",
+    )
+
+    op.add_column(
+        "price_change_request",
+        sa.Column("rejected_by_user_id", sa.Integer(), nullable=True),
+        schema="pct_core",
+    )
+
+    op.add_column(
+        "price_change_request",
+        sa.Column("rejected_at", sa.DateTime(timezone=True), nullable=True),
+        schema="pct_core",
+    )
+
+    op.create_foreign_key(
+        "fk_price_change_request_rejected_by_user",
+        "price_change_request",
+        "user_account",
+        ["rejected_by_user_id"],
+        ["id"],
+        source_schema="pct_core",
+        referent_schema="pct_core",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_price_change_request_rejected_by_user",
+        "price_change_request",
+        schema="pct_core",
+        type_="foreignkey",
+    )
+
+    op.drop_column(
+        "price_change_request",
+        "rejected_at",
+        schema="pct_core",
+    )
+
+    op.drop_column(
+        "price_change_request",
+        "rejected_by_user_id",
+        schema="pct_core",
+    )
+
+    op.drop_column(
+        "price_change_request",
+        "rejection_reason",
+        schema="pct_core",
+    )

--- a/backend/alembic/versions/ce9a2d7a81b5_add_rejection_fields_to_price_change_.py
+++ b/backend/alembic/versions/ce9a2d7a81b5_add_rejection_fields_to_price_change_.py
@@ -7,9 +7,9 @@ Create Date: 2026-05-06 10:11:45.416715
 """
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = 'ce9a2d7a81b5'

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -7,6 +7,7 @@ from .routes.products import router as products_router
 from .routes.promotions import router as promotions_router
 from .routes.sales import router as sales_router
 from .routes.technical import router as technical_router
+from .routes.price_change_requests import router as price_change_requests_router
 
 api_router = APIRouter()
 
@@ -17,3 +18,4 @@ api_router.include_router(promotions_router)
 api_router.include_router(sales_router)
 api_router.include_router(kpis_router)
 api_router.include_router(anomalies_router)
+api_router.include_router(price_change_requests_router)

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -2,13 +2,13 @@ from fastapi import APIRouter
 
 from .routes.anomalies import router as anomalies_router
 from .routes.kpis import router as kpis_router
+from .routes.price_change_requests import router as price_change_requests_router
+from .routes.price_history import router as price_history_router
 from .routes.prices import router as prices_router
 from .routes.products import router as products_router
 from .routes.promotions import router as promotions_router
 from .routes.sales import router as sales_router
 from .routes.technical import router as technical_router
-from .routes.price_change_requests import router as price_change_requests_router
-from .routes.price_history import router as price_history_router
 
 api_router = APIRouter()
 

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -8,6 +8,7 @@ from .routes.promotions import router as promotions_router
 from .routes.sales import router as sales_router
 from .routes.technical import router as technical_router
 from .routes.price_change_requests import router as price_change_requests_router
+from .routes.price_history import router as price_history_router
 
 api_router = APIRouter()
 
@@ -19,3 +20,4 @@ api_router.include_router(sales_router)
 api_router.include_router(kpis_router)
 api_router.include_router(anomalies_router)
 api_router.include_router(price_change_requests_router)
+api_router.include_router(price_history_router)

--- a/backend/app/api/routes/price_change_requests.py
+++ b/backend/app/api/routes/price_change_requests.py
@@ -6,11 +6,13 @@ from app.schemas.price_change_request import (
     PriceChangeRequestApprove,
     PriceChangeRequestCreate,
     PriceChangeRequestRead,
+    PriceChangeRequestReject
 )
 from app.services.price_change_request_service import (
     approve_and_apply_price_change_request,
     create_price_change_request,
     list_price_change_requests,
+    reject_price_change_request
 )
 
 router = APIRouter(
@@ -69,4 +71,21 @@ def get_price_change_requests_endpoint(
         requested_by_user_id=requested_by_user_id,
         limit=limit,
         offset=offset,
+    )
+
+@router.post(
+    "/{price_change_request_id}/reject",
+    response_model=PriceChangeRequestRead,
+    status_code=status.HTTP_200_OK,
+)
+def reject_price_change_request_endpoint(
+    price_change_request_id: int,
+    payload: PriceChangeRequestReject,
+    db: Session = Depends(get_db),
+) -> PriceChangeRequestRead:
+    return reject_price_change_request(
+        db=db,
+        price_change_request_id=price_change_request_id,
+        rejected_by_user_id=payload.rejected_by_user_id,
+        reason=payload.reason,
     )

--- a/backend/app/api/routes/price_change_requests.py
+++ b/backend/app/api/routes/price_change_requests.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.orm import Session
 
 from app.db import get_db
@@ -6,7 +6,10 @@ from app.schemas.price_change_request import (
     PriceChangeRequestCreate,
     PriceChangeRequestRead,
 )
-from app.services.price_change_request_service import create_price_change_request
+from app.services.price_change_request_service import (
+    create_price_change_request,
+    list_price_change_requests,
+)
 
 router = APIRouter(
     prefix="/price-change-requests",
@@ -24,3 +27,28 @@ def create_price_change_request_endpoint(
     db: Session = Depends(get_db),
 ) -> PriceChangeRequestRead:
     return create_price_change_request(db=db, payload=payload)
+
+@router.get(
+    "",
+    response_model=list[PriceChangeRequestRead],
+)
+def get_price_change_requests_endpoint(
+    status: str | None = None,
+    product_id: int | None = Query(default=None, gt=0),
+    country_id: int | None = Query(default=None, gt=0),
+    store_id: int | None = Query(default=None, gt=0),
+    requested_by_user_id: int | None = Query(default=None, gt=0),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    db: Session = Depends(get_db),
+) -> list[PriceChangeRequestRead]:
+    return list_price_change_requests(
+        db=db,
+        status=status,
+        product_id=product_id,
+        country_id=country_id,
+        store_id=store_id,
+        requested_by_user_id=requested_by_user_id,
+        limit=limit,
+        offset=offset,
+    )

--- a/backend/app/api/routes/price_change_requests.py
+++ b/backend/app/api/routes/price_change_requests.py
@@ -3,10 +3,12 @@ from sqlalchemy.orm import Session
 
 from app.db import get_db
 from app.schemas.price_change_request import (
+    PriceChangeRequestApprove,
     PriceChangeRequestCreate,
     PriceChangeRequestRead,
 )
 from app.services.price_change_request_service import (
+    approve_and_apply_price_change_request,
     create_price_change_request,
     list_price_change_requests,
 )
@@ -27,6 +29,22 @@ def create_price_change_request_endpoint(
     db: Session = Depends(get_db),
 ) -> PriceChangeRequestRead:
     return create_price_change_request(db=db, payload=payload)
+
+@router.post(
+    "/{price_change_request_id}/approve",
+    response_model=PriceChangeRequestRead,
+    status_code=status.HTTP_200_OK,
+)
+def approve_price_change_request_endpoint(
+    price_change_request_id: int,
+    payload: PriceChangeRequestApprove,
+    db: Session = Depends(get_db),
+) -> PriceChangeRequestRead:
+    return approve_and_apply_price_change_request(
+        db=db,
+        price_change_request_id=price_change_request_id,
+        performed_by_user_id=payload.approved_by_user_id,
+    )
 
 @router.get(
     "",

--- a/backend/app/api/routes/price_change_requests.py
+++ b/backend/app/api/routes/price_change_requests.py
@@ -6,13 +6,13 @@ from app.schemas.price_change_request import (
     PriceChangeRequestApprove,
     PriceChangeRequestCreate,
     PriceChangeRequestRead,
-    PriceChangeRequestReject
+    PriceChangeRequestReject,
 )
 from app.services.price_change_request_service import (
     approve_and_apply_price_change_request,
     create_price_change_request,
     list_price_change_requests,
-    reject_price_change_request
+    reject_price_change_request,
 )
 
 router = APIRouter(

--- a/backend/app/api/routes/price_change_requests.py
+++ b/backend/app/api/routes/price_change_requests.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from app.db import get_db
+from app.schemas.price_change_request import (
+    PriceChangeRequestCreate,
+    PriceChangeRequestRead,
+)
+from app.services.price_change_request_service import create_price_change_request
+
+router = APIRouter(
+    prefix="/price-change-requests",
+    tags=["Price Change Requests"],
+)
+
+
+@router.post(
+    "",
+    response_model=PriceChangeRequestRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_price_change_request_endpoint(
+    payload: PriceChangeRequestCreate,
+    db: Session = Depends(get_db),
+) -> PriceChangeRequestRead:
+    return create_price_change_request(db=db, payload=payload)

--- a/backend/app/api/routes/price_history.py
+++ b/backend/app/api/routes/price_history.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.db import get_db
+from app.schemas.price_history import PriceHistoryRead
+from app.services.price_history_service import list_price_history
+
+router = APIRouter(
+    prefix="/price-history",
+    tags=["Price History"],
+)
+
+
+@router.get(
+    "",
+    response_model=list[PriceHistoryRead],
+)
+def get_price_history_endpoint(
+    price_change_request_id: int | None = Query(default=None, gt=0),
+    product_id: int | None = Query(default=None, gt=0),
+    country_id: int | None = Query(default=None, gt=0),
+    store_id: int | None = Query(default=None, gt=0),
+    applied_by_user_id: int | None = Query(default=None, gt=0),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    db: Session = Depends(get_db),
+) -> list[PriceHistoryRead]:
+    return list_price_history(
+        db=db,
+        price_change_request_id=price_change_request_id,
+        product_id=product_id,
+        country_id=country_id,
+        store_id=store_id,
+        applied_by_user_id=applied_by_user_id,
+        limit=limit,
+        offset=offset,
+    )

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,21 +1,29 @@
 from app.models.audit_log import AuditLog
 from app.models.base import Base
+from app.models.country import Country
 from app.models.price import Price
 from app.models.price_change_request import PriceChangeRequest
 from app.models.price_history import PriceHistory
 from app.models.product import Product
 from app.models.product_family import ProductFamily
+from app.models.product_image import ProductImage
 from app.models.promotion import Promotion
 from app.models.sales_transaction import SalesTransaction
+from app.models.store import Store
+from app.models.user_account import UserAccount
 
 __all__ = [
-    "Base", 
-    "Product", 
-    "ProductFamily", 
-    "Price", 
-    "Promotion", 
+    "Base",
+    "Country",
+    "Store",
+    "UserAccount",
+    "Product",
+    "ProductFamily",
+    "ProductImage",
+    "Price",
+    "Promotion",
     "SalesTransaction",
     "PriceChangeRequest",
     "AuditLog",
-    "PriceHistory"
+    "PriceHistory",
 ]

--- a/backend/app/models/country.py
+++ b/backend/app/models/country.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .store import Store
+
+
 from sqlalchemy import Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 

--- a/backend/app/models/country.py
+++ b/backend/app/models/country.py
@@ -4,7 +4,6 @@ from sqlalchemy import Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
-from app.models.store import Store
 
 
 class Country(Base):

--- a/backend/app/models/country.py
+++ b/backend/app/models/country.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+
+class Country(Base):
+    __tablename__ = "country"
+    __table_args__ = {"schema": "pct_core"}
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    code: Mapped[str] = mapped_column(String(10), nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+
+    stores: Mapped[list["Store"]] = relationship(back_populates="country")

--- a/backend/app/models/country.py
+++ b/backend/app/models/country.py
@@ -4,6 +4,7 @@ from sqlalchemy import Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
+from app.models.store import Store
 
 
 class Country(Base):

--- a/backend/app/models/price_change_request.py
+++ b/backend/app/models/price_change_request.py
@@ -72,7 +72,24 @@ class PriceChangeRequest(Base):
         ),
         nullable=False,
     )
+    rejection_reason: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+    )
 
+    rejected_by_user_id: Mapped[int | None] = mapped_column(
+        ForeignKey(
+            "pct_core.user_account.id",
+            name="fk_price_change_request_rejected_by_user",
+        ),
+        nullable=True,
+    )
+
+    rejected_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/backend/app/models/product.py
+++ b/backend/app/models/product.py
@@ -26,3 +26,5 @@ class Product(Base):
     family: Mapped[ProductFamily] = relationship(
         back_populates="products",
     )
+
+    images: Mapped[list["ProductImage"]] = relationship(back_populates="product")

--- a/backend/app/models/product.py
+++ b/backend/app/models/product.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
 from app.models.product_family import ProductFamily
+from app.models.product_image import ProductImage
 
 
 class Product(Base):

--- a/backend/app/models/product_image.py
+++ b/backend/app/models/product_image.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from sqlalchemy import ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+
+class ProductImage(Base):
+    __tablename__ = "product_image"
+    __table_args__ = {"schema": "pct_core"}
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    product_id: Mapped[int] = mapped_column(
+        ForeignKey("pct_core.product.id", name="fk_product_image_product"),
+        nullable=False,
+    )
+    image_url: Mapped[str] = mapped_column(String(500), nullable=False)
+    alt_text: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    display_order: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+
+    product: Mapped["Product"] = relationship(back_populates="images")

--- a/backend/app/models/product_image.py
+++ b/backend/app/models/product_image.py
@@ -4,7 +4,6 @@ from sqlalchemy import ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
-from app.models.product import Product
 
 
 class ProductImage(Base):

--- a/backend/app/models/product_image.py
+++ b/backend/app/models/product_image.py
@@ -4,6 +4,7 @@ from sqlalchemy import ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
+from app.models.product import Product
 
 
 class ProductImage(Base):

--- a/backend/app/models/product_image.py
+++ b/backend/app/models/product_image.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .product import Product
+
 from sqlalchemy import ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 

--- a/backend/app/models/store.py
+++ b/backend/app/models/store.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy import Date, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+
+class Store(Base):
+    __tablename__ = "store"
+    __table_args__ = {"schema": "pct_core"}
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    code: Mapped[str] = mapped_column(String(20), nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    country_id: Mapped[int] = mapped_column(
+        ForeignKey("pct_core.country.id", name="fk_store_country"),
+        nullable=False,
+    )
+    city: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    region: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    opening_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+
+    country: Mapped["Country"] = relationship(back_populates="stores")

--- a/backend/app/models/store.py
+++ b/backend/app/models/store.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .country import Country
+
 from datetime import date
 
 from sqlalchemy import Date, ForeignKey, Integer, String

--- a/backend/app/models/store.py
+++ b/backend/app/models/store.py
@@ -6,7 +6,6 @@ from sqlalchemy import Date, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
-from app.models.country import Country
 
 
 class Store(Base):

--- a/backend/app/models/store.py
+++ b/backend/app/models/store.py
@@ -6,6 +6,7 @@ from sqlalchemy import Date, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
+from app.models.country import Country
 
 
 class Store(Base):

--- a/backend/app/models/user_account.py
+++ b/backend/app/models/user_account.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from sqlalchemy import Boolean, Integer, String, true
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class UserAccount(Base):
+    __tablename__ = "user_account"
+    __table_args__ = {"schema": "pct_core"}
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    full_name: Mapped[str] = mapped_column(String(150), nullable=False)
+    active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=true())

--- a/backend/app/schemas/price_change_request.py
+++ b/backend/app/schemas/price_change_request.py
@@ -8,7 +8,6 @@ class PriceChangeRequestCreate(BaseModel):
     product_id: int = Field(gt=0)
     country_id: int = Field(gt=0)
     store_id: int | None = Field(default=None, gt=0)
-    current_price_id: int = Field(gt=0)
 
     requested_price_amount: Decimal = Field(gt=0, max_digits=10, decimal_places=2)
     justification: str = Field(min_length=1)

--- a/backend/app/schemas/price_change_request.py
+++ b/backend/app/schemas/price_change_request.py
@@ -41,7 +41,10 @@ class PriceChangeRequestRead(BaseModel):
     requested_effective_date: date
 
     requested_by_user_id: int
-
+    rejection_reason: str | None = None
+    rejected_by_user_id: int | None = None
+    rejected_at: datetime | None = None
+    
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/schemas/price_history.py
+++ b/backend/app/schemas/price_history.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PriceHistoryRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    history_id: int
+    price_change_request_id: int
+
+    product_id: int
+    country_id: int
+    store_id: int | None
+
+    previous_price_id: int
+    new_price_id: int
+
+    old_price_amount: Decimal
+    new_price_amount: Decimal
+
+    applied_by_user_id: int
+    applied_at: datetime
+    created_at: datetime

--- a/backend/app/services/price_change_request_service.py
+++ b/backend/app/services/price_change_request_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timezone, timedelta
 
 from fastapi import HTTPException, status as http_status
 from sqlalchemy import select
@@ -319,6 +319,79 @@ def approve_and_apply_price_change_request(
     db.refresh(price_change_request)
 
     return price_change_request
+
+def reject_price_change_request(
+    db: Session,
+    price_change_request_id: int,
+    rejected_by_user_id: int,
+    reason: str,
+) -> PriceChangeRequest:
+    price_change_request = db.scalar(
+        select(PriceChangeRequest).where(
+            PriceChangeRequest.id == price_change_request_id
+        )
+    )
+
+    if price_change_request is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="Price change request not found",
+        )
+
+    if price_change_request.status != "PENDING":
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail="Only PENDING price change requests can be rejected",
+        )
+
+    rejected_by_user = db.scalar(
+        select(UserAccount).where(UserAccount.id == rejected_by_user_id)
+    )
+
+    if rejected_by_user is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="Rejecting user not found",
+        )
+
+    cleaned_reason = reason.strip()
+
+    if not cleaned_reason:
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail="Rejection reason must not be empty",
+        )
+
+    try:
+        price_change_request.status = "REJECTED"
+        price_change_request.rejection_reason = cleaned_reason
+        price_change_request.rejected_by_user_id = rejected_by_user_id
+        price_change_request.rejected_at = datetime.now(timezone.utc)
+
+        audit_log = AuditLog(
+            price_change_request_id=price_change_request.id,
+            action_type="REQUEST_REJECTED",
+            performed_by_user_id=rejected_by_user_id,
+            description=(
+                "Price change request rejected. "
+                f"Request ID: {price_change_request.id}, "
+                f"Product ID: {price_change_request.product_id}, "
+                f"Country ID: {price_change_request.country_id}, "
+                f"Store ID: {price_change_request.store_id}, "
+                f"Current price ID: {price_change_request.current_price_id}, "
+                f"Reason: {cleaned_reason}."
+            ),
+        )
+
+        db.add(audit_log)
+        db.commit()
+        db.refresh(price_change_request)
+
+        return price_change_request
+
+    except Exception:
+        db.rollback()
+        raise
 
 def get_current_applicable_standard_price(
     db: Session,

--- a/backend/app/services/price_change_request_service.py
+++ b/backend/app/services/price_change_request_service.py
@@ -69,6 +69,8 @@ def create_price_change_request(
         product_id=payload.product_id,
         country_id=payload.country_id,
         store_id=payload.store_id,
+        as_of_date=payload.requested_effective_date,
+
     )
 
     if current_price is None:
@@ -323,16 +325,20 @@ def get_current_applicable_standard_price(
     product_id: int,
     country_id: int,
     store_id: int | None,
+    as_of_date: date | None = None,
 ) -> Price | None:
-    today = date.today()
+    reference_date = as_of_date or date.today()
 
     base_conditions = [
         Price.product_id == product_id,
         Price.country_id == country_id,
         Price.price_type == "STANDARD",
         Price.status == "ACTIVE",
-        Price.effective_from <= today,
-        (Price.effective_to.is_(None) | (Price.effective_to >= today)),
+        Price.effective_from <= reference_date,
+        (
+            Price.effective_to.is_(None)
+            | (Price.effective_to >= reference_date)
+        ),
     ]
 
     if store_id is not None:

--- a/backend/app/services/price_change_request_service.py
+++ b/backend/app/services/price_change_request_service.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timezone, timedelta
+from datetime import date, datetime, timedelta, timezone
 
-from fastapi import HTTPException, status as http_status
+from fastapi import HTTPException
+from fastapi import status as http_status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.models.audit_log import AuditLog
+from app.models.country import Country
 from app.models.price import Price
 from app.models.price_change_request import PriceChangeRequest
 from app.models.price_history import PriceHistory
 from app.models.product import Product
 from app.models.store import Store
-from app.models.country import Country
 from app.models.user_account import UserAccount
 from app.schemas.price_change_request import PriceChangeRequestCreate
 

--- a/backend/app/services/price_change_request_service.py
+++ b/backend/app/services/price_change_request_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 
 from fastapi import HTTPException, status as http_status
 from sqlalchemy import select
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 from app.models.audit_log import AuditLog
 from app.models.price import Price
 from app.models.price_change_request import PriceChangeRequest
+from app.models.price_history import PriceHistory
 from app.models.product import Product
 from app.models.store import Store
 from app.models.country import Country
@@ -163,6 +164,158 @@ def list_price_change_requests(
     )
 
     return list(db.scalars(query).all())
+def approve_and_apply_price_change_request(
+    db: Session,
+    price_change_request_id: int,
+    performed_by_user_id: int,
+) -> PriceChangeRequest:
+    price_change_request = db.scalar(
+        select(PriceChangeRequest).where(
+            PriceChangeRequest.id == price_change_request_id
+        )
+    )
+
+    if price_change_request is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="Price change request not found",
+        )
+
+    if price_change_request.status != "PENDING":
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail="Only PENDING price change requests can be approved and applied",
+        )
+
+    performer = db.scalar(
+        select(UserAccount).where(UserAccount.id == performed_by_user_id)
+    )
+    if performer is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="Performing user not found",
+        )
+
+    current_price = db.scalar(
+        select(Price).where(Price.id == price_change_request.current_price_id)
+    )
+
+    if current_price is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="Current price not found",
+        )
+
+    if current_price.product_id != price_change_request.product_id:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail="Current price product does not match request product",
+        )
+
+    if current_price.country_id != price_change_request.country_id:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail="Current price country does not match request country",
+        )
+
+    if current_price.store_id != price_change_request.store_id:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail="Current price store does not match request store",
+        )
+
+    if current_price.price_type != "STANDARD":
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail="Only STANDARD prices can be changed through this workflow",
+        )
+
+    if current_price.status != "ACTIVE":
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail="Only ACTIVE prices can be changed through this workflow",
+        )
+
+    requested_effective_date = price_change_request.requested_effective_date
+
+    if requested_effective_date <= current_price.effective_from:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail=(
+                "Requested effective date must be after the current price "
+                "effective start date"
+            ),
+        )
+
+    if (
+        current_price.effective_to is not None
+        and current_price.effective_to < requested_effective_date
+    ):
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail="Current price is already closed before the requested effective date",
+        )
+
+    new_price_scope = (
+        "STORE"
+        if price_change_request.store_id is not None
+        else "COUNTRY"
+    )
+
+    current_price.effective_to = requested_effective_date - timedelta(days=1)
+
+    new_price = Price(
+        product_id=price_change_request.product_id,
+        country_id=price_change_request.country_id,
+        store_id=price_change_request.store_id,
+        price_scope=new_price_scope,
+        price_type="STANDARD",
+        amount=price_change_request.requested_price_amount,
+        effective_from=requested_effective_date,
+        effective_to=None,
+        status="ACTIVE",
+        promotion_id=None,
+    )
+
+    db.add(new_price)
+    db.flush()
+
+    price_change_request.status = "APPLIED"
+
+    price_history = PriceHistory(
+        price_change_request_id=price_change_request.id,
+        previous_price_id=current_price.id,
+        new_price_id=new_price.id,
+        old_price_amount=price_change_request.old_price_amount,
+        new_price_amount=price_change_request.requested_price_amount,
+        changed_by_user_id=performed_by_user_id,
+    )
+
+    db.add(price_history)
+
+    audit_log = AuditLog(
+        price_change_request_id=price_change_request.id,
+        action_type="REQUEST_APPLIED",
+        performed_by_user_id=performed_by_user_id,
+        description=(
+            "Price change request approved and applied. "
+            f"Request ID: {price_change_request.id}, "
+            f"Product ID: {price_change_request.product_id}, "
+            f"Country ID: {price_change_request.country_id}, "
+            f"Store ID: {price_change_request.store_id}, "
+            f"Previous price ID: {current_price.id}, "
+            f"New price ID: {new_price.id}, "
+            f"Old price amount: {price_change_request.old_price_amount}, "
+            f"New price amount: {price_change_request.requested_price_amount}, "
+            f"Effective date: {requested_effective_date}."
+        ),
+    )
+
+    db.add(audit_log)
+    db.commit()
+    db.refresh(price_change_request)
+
+    return price_change_request
 
 def get_current_applicable_standard_price(
     db: Session,

--- a/backend/app/services/price_change_request_service.py
+++ b/backend/app/services/price_change_request_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import date
 
-from fastapi import HTTPException, status
+from fastapi import HTTPException, status as http_status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -25,7 +25,7 @@ def create_price_change_request(
     )
     if product is None:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
+            status_code=http_status.HTTP_404_NOT_FOUND,
             detail="Product not found",
         )
 
@@ -34,7 +34,7 @@ def create_price_change_request(
     )
     if country is None:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
+            status_code=http_status.HTTP_404_NOT_FOUND,
             detail="Country not found",
         )
 
@@ -43,7 +43,7 @@ def create_price_change_request(
     )
     if requester is None:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
+            status_code=http_status.HTTP_404_NOT_FOUND,
             detail="Requesting user not found",
         )
 
@@ -53,13 +53,13 @@ def create_price_change_request(
         )
         if store is None:
             raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
+                status_code=http_status.HTTP_404_NOT_FOUND,
                 detail="Store not found",
             )
 
         if store.country_id != payload.country_id:
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
+                status_code=http_status.HTTP_400_BAD_REQUEST,
                 detail="Store does not belong to selected country",
             )
 
@@ -72,7 +72,7 @@ def create_price_change_request(
 
     if current_price is None:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
+            status_code=http_status.HTTP_404_NOT_FOUND,
             detail="Current applicable standard price not found",
         )
 
@@ -113,6 +113,56 @@ def create_price_change_request(
 
     return price_change_request
 
+def list_price_change_requests(
+    db: Session,
+    status: str | None = None,
+    product_id: int | None = None,
+    country_id: int | None = None,
+    store_id: int | None = None,
+    requested_by_user_id: int | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[PriceChangeRequest]:
+    allowed_statuses = {
+        "PENDING",
+        "APPROVED",
+        "REJECTED",
+        "APPLIED",
+        "FAILED",
+    }
+
+    if status is not None and status not in allowed_statuses:
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail="Invalid price change request status",
+        )
+
+    query = select(PriceChangeRequest)
+
+    if status is not None:
+        query = query.where(PriceChangeRequest.status == status)
+
+    if product_id is not None:
+        query = query.where(PriceChangeRequest.product_id == product_id)
+
+    if country_id is not None:
+        query = query.where(PriceChangeRequest.country_id == country_id)
+
+    if store_id is not None:
+        query = query.where(PriceChangeRequest.store_id == store_id)
+
+    if requested_by_user_id is not None:
+        query = query.where(
+            PriceChangeRequest.requested_by_user_id == requested_by_user_id
+        )
+
+    query = (
+        query.order_by(PriceChangeRequest.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+
+    return list(db.scalars(query).all())
 
 def get_current_applicable_standard_price(
     db: Session,
@@ -153,3 +203,4 @@ def get_current_applicable_standard_price(
         )
 
     return db.scalar(query)
+

--- a/backend/app/services/price_change_request_service.py
+++ b/backend/app/services/price_change_request_service.py
@@ -275,6 +275,7 @@ def approve_and_apply_price_change_request(
         effective_to=None,
         status="ACTIVE",
         promotion_id=None,
+        created_by=performed_by_user_id,
     )
 
     db.add(new_price)
@@ -288,14 +289,14 @@ def approve_and_apply_price_change_request(
         new_price_id=new_price.id,
         old_price_amount=price_change_request.old_price_amount,
         new_price_amount=price_change_request.requested_price_amount,
-        changed_by_user_id=performed_by_user_id,
+        applied_by_user_id=performed_by_user_id,
     )
 
     db.add(price_history)
 
     audit_log = AuditLog(
         price_change_request_id=price_change_request.id,
-        action_type="REQUEST_APPLIED",
+        action_type="PRICE_APPLIED",
         performed_by_user_id=performed_by_user_id,
         description=(
             "Price change request approved and applied. "

--- a/backend/app/services/price_change_request_service.py
+++ b/backend/app/services/price_change_request_service.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.audit_log import AuditLog
+from app.models.price import Price
+from app.models.price_change_request import PriceChangeRequest
+from app.models.product import Product
+from app.models.store import Store
+from app.models.country import Country
+from app.models.user_account import UserAccount
+from app.schemas.price_change_request import PriceChangeRequestCreate
+
+
+def create_price_change_request(
+    db: Session,
+    payload: PriceChangeRequestCreate,
+) -> PriceChangeRequest:
+    product = db.scalar(
+        select(Product).where(Product.id == payload.product_id)
+    )
+    if product is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Product not found",
+        )
+
+    country = db.scalar(
+        select(Country).where(Country.id == payload.country_id)
+    )
+    if country is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Country not found",
+        )
+
+    requester = db.scalar(
+        select(UserAccount).where(UserAccount.id == payload.requested_by_user_id)
+    )
+    if requester is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Requesting user not found",
+        )
+
+    if payload.store_id is not None:
+        store = db.scalar(
+            select(Store).where(Store.id == payload.store_id)
+        )
+        if store is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Store not found",
+            )
+
+        if store.country_id != payload.country_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Store does not belong to selected country",
+            )
+
+    current_price = get_current_applicable_standard_price(
+        db=db,
+        product_id=payload.product_id,
+        country_id=payload.country_id,
+        store_id=payload.store_id,
+    )
+
+    if current_price is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Current applicable standard price not found",
+        )
+
+    price_change_request = PriceChangeRequest(
+        product_id=payload.product_id,
+        country_id=payload.country_id,
+        store_id=payload.store_id,
+        current_price_id=current_price.id,
+        old_price_amount=current_price.amount,
+        requested_price_amount=payload.requested_price_amount,
+        status="PENDING",
+        justification=payload.justification,
+        requested_effective_date=payload.requested_effective_date,
+        requested_by_user_id=payload.requested_by_user_id,
+    )
+
+    db.add(price_change_request)
+    db.flush()
+
+    audit_log = AuditLog(
+        price_change_request_id=price_change_request.id,
+        action_type="REQUEST_CREATED",
+        performed_by_user_id=payload.requested_by_user_id,
+        description=(
+            "Price change request created with status PENDING. "
+            f"Product ID: {payload.product_id}, "
+            f"Country ID: {payload.country_id}, "
+            f"Store ID: {payload.store_id}, "
+            f"Current price ID: {current_price.id}, "
+            f"Old price amount: {current_price.amount}, "
+            f"Requested price amount: {payload.requested_price_amount}."
+        ),
+    )
+
+    db.add(audit_log)
+    db.commit()
+    db.refresh(price_change_request)
+
+    return price_change_request
+
+
+def get_current_applicable_standard_price(
+    db: Session,
+    product_id: int,
+    country_id: int,
+    store_id: int | None,
+) -> Price | None:
+    today = date.today()
+
+    base_conditions = [
+        Price.product_id == product_id,
+        Price.country_id == country_id,
+        Price.price_type == "STANDARD",
+        Price.status == "ACTIVE",
+        Price.effective_from <= today,
+        (Price.effective_to.is_(None) | (Price.effective_to >= today)),
+    ]
+
+    if store_id is not None:
+        query = (
+            select(Price)
+            .where(
+                *base_conditions,
+                Price.price_scope == "STORE",
+                Price.store_id == store_id,
+            )
+            .order_by(Price.effective_from.desc())
+        )
+    else:
+        query = (
+            select(Price)
+            .where(
+                *base_conditions,
+                Price.price_scope == "COUNTRY",
+                Price.store_id.is_(None),
+            )
+            .order_by(Price.effective_from.desc())
+        )
+
+    return db.scalar(query)

--- a/backend/app/services/price_history_service.py
+++ b/backend/app/services/price_history_service.py
@@ -1,0 +1,64 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.price_change_request import PriceChangeRequest
+from app.models.price_history import PriceHistory
+
+
+def list_price_history(
+    db: Session,
+    price_change_request_id: int | None = None,
+    product_id: int | None = None,
+    country_id: int | None = None,
+    store_id: int | None = None,
+    applied_by_user_id: int | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[dict]:
+    query = (
+        select(
+            PriceHistory.history_id,
+            PriceHistory.price_change_request_id,
+            PriceChangeRequest.product_id,
+            PriceChangeRequest.country_id,
+            PriceChangeRequest.store_id,
+            PriceHistory.previous_price_id,
+            PriceHistory.new_price_id,
+            PriceHistory.old_price_amount,
+            PriceHistory.new_price_amount,
+            PriceHistory.applied_by_user_id,
+            PriceHistory.applied_at,
+            PriceHistory.created_at,
+        )
+        .join(
+            PriceChangeRequest,
+            PriceChangeRequest.id == PriceHistory.price_change_request_id,
+        )
+    )
+
+    if price_change_request_id is not None:
+        query = query.where(
+            PriceHistory.price_change_request_id == price_change_request_id
+        )
+
+    if product_id is not None:
+        query = query.where(PriceChangeRequest.product_id == product_id)
+
+    if country_id is not None:
+        query = query.where(PriceChangeRequest.country_id == country_id)
+
+    if store_id is not None:
+        query = query.where(PriceChangeRequest.store_id == store_id)
+
+    if applied_by_user_id is not None:
+        query = query.where(PriceHistory.applied_by_user_id == applied_by_user_id)
+
+    query = (
+        query.order_by(PriceHistory.applied_at.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+
+    rows = db.execute(query).mappings().all()
+
+    return [dict(row) for row in rows]

--- a/backend/scripts/manual_validate_price_workflow.sh
+++ b/backend/scripts/manual_validate_price_workflow.sh
@@ -1,0 +1,306 @@
+#!/bin/bash
+
+set -e
+
+API_BASE_URL="http://127.0.0.1:8000"
+DB_NAME="pct"
+DB_USER="pct_user"
+DB_CONTAINER="pct-postgres"
+
+PRODUCT_ID=31
+COUNTRY_ID=5
+STORE_ID=null
+REQUESTED_BY_USER_ID=1
+APPROVED_BY_USER_ID=1
+REJECTED_BY_USER_ID=1
+
+APPROVAL_PRICE_AMOUNT="24.99"
+APPROVAL_EFFECTIVE_DATE="2027-03-01"
+
+REJECTION_PRICE_AMOUNT="26.99"
+REJECTION_EFFECTIVE_DATE="2027-04-01"
+
+echo "=================================================="
+echo "T83 - Manual validation of price change workflow"
+echo "=================================================="
+echo ""
+
+echo "Checking API health..."
+curl -s "${API_BASE_URL}/health"
+echo ""
+echo ""
+
+echo "=================================================="
+echo "Scenario A - Approval workflow"
+echo "=================================================="
+
+echo "Creating a valid price change request for approval..."
+
+APPROVAL_RESPONSE=$(curl -s -X POST "${API_BASE_URL}/price-change-requests" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"product_id\": ${PRODUCT_ID},
+    \"country_id\": ${COUNTRY_ID},
+    \"store_id\": ${STORE_ID},
+    \"requested_price_amount\": \"${APPROVAL_PRICE_AMOUNT}\",
+    \"justification\": \"Manual validation of approval workflow.\",
+    \"requested_effective_date\": \"${APPROVAL_EFFECTIVE_DATE}\",
+    \"requested_by_user_id\": ${REQUESTED_BY_USER_ID}
+  }")
+
+echo "Creation response:"
+echo "${APPROVAL_RESPONSE}"
+echo ""
+
+APPROVAL_REQUEST_ID=$(echo "${APPROVAL_RESPONSE}" | python -c "import sys, json; print(json.load(sys.stdin)['id'])")
+APPROVAL_CURRENT_PRICE_ID=$(echo "${APPROVAL_RESPONSE}" | python -c "import sys, json; print(json.load(sys.stdin)['current_price_id'])")
+
+echo "Approval request ID: ${APPROVAL_REQUEST_ID}"
+echo "Approval current price ID: ${APPROVAL_CURRENT_PRICE_ID}"
+echo ""
+
+echo "Checking initial PENDING status..."
+docker exec -i "${DB_CONTAINER}" psql -U "${DB_USER}" -d "${DB_NAME}" -c "
+select
+    id,
+    status,
+    current_price_id,
+    old_price_amount,
+    requested_price_amount,
+    requested_effective_date
+from pct_core.price_change_request
+where id = ${APPROVAL_REQUEST_ID};
+"
+
+echo "Approving the request..."
+
+APPROVE_RESPONSE=$(curl -s -X POST "${API_BASE_URL}/price-change-requests/${APPROVAL_REQUEST_ID}/approve" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"approved_by_user_id\": ${APPROVED_BY_USER_ID}
+  }")
+
+echo "Approve response:"
+echo "${APPROVE_RESPONSE}"
+echo ""
+
+echo "Checking APPLIED status..."
+docker exec -i "${DB_CONTAINER}" psql -U "${DB_USER}" -d "${DB_NAME}" -c "
+select
+    id,
+    status,
+    current_price_id,
+    old_price_amount,
+    requested_price_amount,
+    requested_effective_date
+from pct_core.price_change_request
+where id = ${APPROVAL_REQUEST_ID};
+"
+
+echo "Checking price_history..."
+docker exec -i "${DB_CONTAINER}" psql -U "${DB_USER}" -d "${DB_NAME}" -c "
+select
+    history_id,
+    price_change_request_id,
+    previous_price_id,
+    new_price_id,
+    old_price_amount,
+    new_price_amount,
+    applied_by_user_id,
+    applied_at
+from pct_core.price_history
+where price_change_request_id = ${APPROVAL_REQUEST_ID};
+"
+
+echo "Checking old and new prices..."
+docker exec -i "${DB_CONTAINER}" psql -U "${DB_USER}" -d "${DB_NAME}" -c "
+select
+    id,
+    product_id,
+    country_id,
+    store_id,
+    price_scope,
+    amount,
+    effective_from,
+    effective_to,
+    status
+from pct_core.price
+where id in (
+    select previous_price_id
+    from pct_core.price_history
+    where price_change_request_id = ${APPROVAL_REQUEST_ID}
+    union
+    select new_price_id
+    from pct_core.price_history
+    where price_change_request_id = ${APPROVAL_REQUEST_ID}
+)
+order by effective_from;
+"
+
+echo "Checking audit_log for approval workflow..."
+docker exec -i "${DB_CONTAINER}" psql -U "${DB_USER}" -d "${DB_NAME}" -c "
+select
+    audit_id,
+    price_change_request_id,
+    action_type,
+    performed_by_user_id,
+    description,
+    created_at
+from pct_core.audit_log
+where price_change_request_id = ${APPROVAL_REQUEST_ID}
+order by created_at;
+"
+
+echo "Checking price-history API endpoint..."
+curl -s "${API_BASE_URL}/price-history?price_change_request_id=${APPROVAL_REQUEST_ID}"
+echo ""
+echo ""
+
+echo "Testing invalid transition: approve an already APPLIED request..."
+
+INVALID_APPROVE_RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "${API_BASE_URL}/price-change-requests/${APPROVAL_REQUEST_ID}/approve" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"approved_by_user_id\": ${APPROVED_BY_USER_ID}
+  }")
+
+echo "${INVALID_APPROVE_RESPONSE}"
+echo ""
+
+echo "=================================================="
+echo "Scenario B - Rejection workflow"
+echo "=================================================="
+
+echo "Creating a valid price change request for rejection..."
+
+REJECTION_RESPONSE=$(curl -s -X POST "${API_BASE_URL}/price-change-requests" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"product_id\": ${PRODUCT_ID},
+    \"country_id\": ${COUNTRY_ID},
+    \"store_id\": ${STORE_ID},
+    \"requested_price_amount\": \"${REJECTION_PRICE_AMOUNT}\",
+    \"justification\": \"Manual validation of rejection workflow.\",
+    \"requested_effective_date\": \"${REJECTION_EFFECTIVE_DATE}\",
+    \"requested_by_user_id\": ${REQUESTED_BY_USER_ID}
+  }")
+
+echo "Creation response:"
+echo "${REJECTION_RESPONSE}"
+echo ""
+
+REJECT_REQUEST_ID=$(echo "${REJECTION_RESPONSE}" | python -c "import sys, json; print(json.load(sys.stdin)['id'])")
+REJECT_CURRENT_PRICE_ID=$(echo "${REJECTION_RESPONSE}" | python -c "import sys, json; print(json.load(sys.stdin)['current_price_id'])")
+
+echo "Reject request ID: ${REJECT_REQUEST_ID}"
+echo "Reject current price ID: ${REJECT_CURRENT_PRICE_ID}"
+echo ""
+
+echo "Checking price before rejection..."
+docker exec -i "${DB_CONTAINER}" psql -U "${DB_USER}" -d "${DB_NAME}" -c "
+select
+    id,
+    product_id,
+    country_id,
+    store_id,
+    price_scope,
+    amount,
+    effective_from,
+    effective_to,
+    status
+from pct_core.price
+where id = ${REJECT_CURRENT_PRICE_ID};
+"
+
+echo "Rejecting the request..."
+
+REJECT_RESPONSE=$(curl -s -X POST "${API_BASE_URL}/price-change-requests/${REJECT_REQUEST_ID}/reject" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"rejected_by_user_id\": ${REJECTED_BY_USER_ID},
+    \"reason\": \"Requested price is not aligned with the pricing strategy.\"
+  }")
+
+echo "Reject response:"
+echo "${REJECT_RESPONSE}"
+echo ""
+
+echo "Checking REJECTED status and rejection fields..."
+docker exec -i "${DB_CONTAINER}" psql -U "${DB_USER}" -d "${DB_NAME}" -c "
+select
+    id,
+    status,
+    rejection_reason,
+    rejected_by_user_id,
+    rejected_at
+from pct_core.price_change_request
+where id = ${REJECT_REQUEST_ID};
+"
+
+echo "Checking price after rejection. It must be unchanged..."
+docker exec -i "${DB_CONTAINER}" psql -U "${DB_USER}" -d "${DB_NAME}" -c "
+select
+    id,
+    product_id,
+    country_id,
+    store_id,
+    price_scope,
+    amount,
+    effective_from,
+    effective_to,
+    status
+from pct_core.price
+where id = ${REJECT_CURRENT_PRICE_ID};
+"
+
+echo "Checking that no price_history was created for rejected request..."
+docker exec -i "${DB_CONTAINER}" psql -U "${DB_USER}" -d "${DB_NAME}" -c "
+select *
+from pct_core.price_history
+where price_change_request_id = ${REJECT_REQUEST_ID};
+"
+
+echo "Checking audit_log for rejection workflow..."
+docker exec -i "${DB_CONTAINER}" psql -U "${DB_USER}" -d "${DB_NAME}" -c "
+select
+    audit_id,
+    price_change_request_id,
+    action_type,
+    performed_by_user_id,
+    description,
+    created_at
+from pct_core.audit_log
+where price_change_request_id = ${REJECT_REQUEST_ID}
+order by created_at;
+"
+
+echo "Testing invalid transition: reject an already REJECTED request..."
+
+INVALID_REJECT_RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "${API_BASE_URL}/price-change-requests/${REJECT_REQUEST_ID}/reject" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"rejected_by_user_id\": ${REJECTED_BY_USER_ID},
+    \"reason\": \"Second rejection attempt.\"
+  }")
+
+echo "${INVALID_REJECT_RESPONSE}"
+echo ""
+
+echo "=================================================="
+echo "T83 validation completed"
+echo "=================================================="
+echo ""
+echo "Expected validation points:"
+echo "- Approval request is created with PENDING status."
+echo "- Approval endpoint changes status to APPLIED."
+echo "- Previous price is closed."
+echo "- New price is created."
+echo "- price_history contains before/after values."
+echo "- audit_log contains REQUEST_CREATED and PRICE_APPLIED."
+echo "- Rejection request is created with PENDING status."
+echo "- Reject endpoint changes status to REJECTED."
+echo "- Rejection reason is stored."
+echo "- No price_history is created for rejected request."
+echo "- Price is unchanged after rejection."
+echo "- audit_log contains REQUEST_CREATED and REQUEST_REJECTED."
+echo "- Invalid transitions return 409 Conflict."

--- a/backend/test.py
+++ b/backend/test.py
@@ -1,0 +1,24 @@
+from app.db import SessionLocal
+from app.services.price_change_request_service import reject_price_change_request
+
+REQUEST_ID = 10
+REJECTED_BY_USER_ID = 1
+
+db = SessionLocal()
+
+try:
+    request = reject_price_change_request(
+        db=db,
+        price_change_request_id=REQUEST_ID,
+        rejected_by_user_id=REJECTED_BY_USER_ID,
+        reason="Requested price increase is not aligned with current pricing strategy.",
+    )
+
+    print(request.id)
+    print(request.status)
+    print(request.rejection_reason)
+    print(request.rejected_by_user_id)
+    print(request.rejected_at)
+
+finally:
+    db.close()

--- a/docs/03_architecture/api_design.md
+++ b/docs/03_architecture/api_design.md
@@ -435,7 +435,55 @@ Returns the updated price change request with `status: "APPROVED"` and `approved
 
 ---
 
-# 10. POST /price-change-requests/{id}/reject
+
+# 11. GET /price-history
+
+## Business purpose
+
+Retrieve the history of price changes for audit and traceability.
+
+---
+
+## Query parameters
+
+| Parameter           | Type    | Description                |
+| ------------------- | ------- | -------------------------- |
+| price_change_request_id | int | Filter by request id       |
+| previous_price_id   | int     | Filter by previous price   |
+| new_price_id        | int     | Filter by new price        |
+| applied_by_user_id  | int     | Filter by user             |
+| ...                 | ...     | ...                        |
+
+---
+
+## Response structure
+
+```json
+[
+  {
+    "id": 1,
+    "price_change_request_id": 42,
+    "previous_price_id": 10,
+    "new_price_id": 11,
+    "old_price_amount": 99.99,
+    "new_price_amount": 89.99,
+    "applied_by_user_id": 2,
+    "applied_at": "2026-05-06T10:00:00Z",
+    "created_at": "2026-05-06T10:00:00Z"
+  }
+]
+```
+
+---
+
+# Changelog
+
+## Sprint 4
+
+- The PriceHistoryRead schema was aligned with other models:
+    - Field `history_id` renamed to `id`.
+    - Only database fields are exposed (removed product_id, country_id, store_id from schema).
+    - Added docstring for clarity and maintainability.
 
 ## Business purpose
 

--- a/docs/03_architecture/api_design.md
+++ b/docs/03_architecture/api_design.md
@@ -319,6 +319,196 @@ MVP rule: flag promotions whose total revenue is **below a configurable threshol
 
 ---
 
+# 7. POST /price-change-requests
+
+## Business purpose
+
+Create a new price change request to initiate a pricing workflow.
+
+---
+
+## Request body
+
+```json
+{
+  "product_id": 1,
+  "price_id": 10,
+  "requested_by_user_id": 1,
+  "new_amount": 89.99,
+  "reason": "Align price with competitor"
+}
+```
+
+---
+
+## Response structure
+
+```json
+{
+  "id": 1,
+  "product_id": 1,
+  "price_id": 10,
+  "requested_by_user_id": 1,
+  "new_amount": 89.99,
+  "reason": "Align price with competitor",
+  "status": "PENDING",
+  "created_at": "2026-05-01T10:00:00Z",
+  "approved_at": null,
+  "rejection_reason": null,
+  "rejected_by_user_id": null,
+  "rejected_at": null
+}
+```
+
+---
+
+# 8. GET /price-change-requests
+
+## Business purpose
+
+List all price change requests with optional filters.
+
+---
+
+## Query parameters
+
+| Parameter | Type   | Description                            |
+| --------- | ------ | -------------------------------------- |
+| status    | string | Filter by status (PENDING, APPROVED, REJECTED) |
+
+---
+
+## Response structure
+
+```json
+[
+  {
+    "id": 1,
+    "product_id": 1,
+    "price_id": 10,
+    "requested_by_user_id": 1,
+    "new_amount": 89.99,
+    "reason": "Align price with competitor",
+    "status": "PENDING",
+    "created_at": "2026-05-01T10:00:00Z",
+    "approved_at": null,
+    "rejection_reason": null,
+    "rejected_by_user_id": null,
+    "rejected_at": null
+  }
+]
+```
+
+---
+
+# 9. POST /price-change-requests/{id}/approve
+
+## Business purpose
+
+Approve a pending price change request and apply the new price.
+
+---
+
+## Request body
+
+```json
+{
+  "approved_by_user_id": 2
+}
+```
+
+---
+
+## Response structure
+
+Returns the updated price change request with `status: "APPROVED"` and `approved_at` timestamp.
+
+---
+
+## Error cases
+
+| HTTP Code | Condition                              |
+| --------- | -------------------------------------- |
+| 404       | Price change request not found         |
+| 409       | Request is not in PENDING status       |
+| 404       | approved_by_user_id does not exist     |
+
+---
+
+# 10. POST /price-change-requests/{id}/reject
+
+## Business purpose
+
+Reject a pending price change request with a mandatory reason.
+
+Used for:
+
+* pricing governance
+* documenting why a request was denied
+* maintaining audit trail
+
+---
+
+## Request body
+
+```json
+{
+  "rejected_by_user_id": 2,
+  "reason": "Price reduction too aggressive for current margin targets"
+}
+```
+
+---
+
+## Validation rules
+
+| Field               | Rule                              |
+| ------------------- | --------------------------------- |
+| rejected_by_user_id | Must be > 0, must exist in system |
+| reason              | Must not be empty after trimming  |
+
+---
+
+## Response structure
+
+```json
+{
+  "id": 1,
+  "product_id": 1,
+  "price_id": 10,
+  "requested_by_user_id": 1,
+  "new_amount": 89.99,
+  "reason": "Align price with competitor",
+  "status": "REJECTED",
+  "created_at": "2026-05-01T10:00:00Z",
+  "approved_at": null,
+  "rejection_reason": "Price reduction too aggressive for current margin targets",
+  "rejected_by_user_id": 2,
+  "rejected_at": "2026-05-02T09:15:00Z"
+}
+```
+
+---
+
+## Error cases
+
+| HTTP Code | Condition                              |
+| --------- | -------------------------------------- |
+| 404       | Price change request not found         |
+| 409       | Request is not in PENDING status       |
+| 404       | rejected_by_user_id does not exist     |
+| 400       | Reason is empty or blank               |
+
+---
+
+## Side effects
+
+* Status updated to `REJECTED`
+* `rejection_reason`, `rejected_by_user_id`, `rejected_at` populated
+* Audit log entry created with `action_type = REQUEST_REJECTED`
+
+---
+
 # Design principles
 
 * Simple REST endpoints
@@ -332,6 +522,5 @@ MVP rule: flag promotions whose total revenue is **below a configurable threshol
 # Next evolutions
 
 * Add filters and pagination improvements
-* Add write endpoints (price changes)
 * Add authentication and roles
 * Add AI assistant integration

--- a/docs/03_architecture/pricing_workflow.md
+++ b/docs/03_architecture/pricing_workflow.md
@@ -1,0 +1,91 @@
+# Pricing Workflow — Functional & Technical Documentation
+
+## Objective
+
+Ensure functional and technical traceability of the price change workflow.
+
+---
+
+## 1. Workflow Statuses
+
+A price change request (`PriceChangeRequest`) can have the following statuses:
+
+| Status     | Description                                      |
+|------------|--------------------------------------------------|
+| PENDING    | Request created, awaiting approval or rejection  |
+| APPROVED   | Request approved, new price applied              |
+| REJECTED   | Request rejected, no price change                |
+
+---
+
+## 2. Lifecycle of a Price Change Request
+
+1. **Creation**: A user submits a price change request (status: PENDING).
+2. **Approval**: An authorized user approves the request (status: APPROVED). The new price is applied, and a `PriceHistory` entry is created.
+3. **Rejection**: An authorized user rejects the request (status: REJECTED). The reason and user are recorded.
+
+State transitions:
+
+- PENDING → APPROVED (via approval endpoint)
+- PENDING → REJECTED (via rejection endpoint)
+
+A request cannot be approved or rejected twice.
+
+---
+
+## 3. Endpoints
+
+- `POST /price-change-requests` — Create a new price change request
+- `GET /price-change-requests` — List all requests (with filters)
+- `POST /price-change-requests/{id}/approve` — Approve and apply a request
+- `POST /price-change-requests/{id}/reject` — Reject a request with a reason
+- `GET /price-history` — List all price change history entries
+
+See [API Design](../03_architecture/api_design.md) for details on request/response formats.
+
+---
+
+## 4. Application Rules for a New Price
+
+- Only requests with status `PENDING` can be approved or rejected.
+- Approval applies the new price (creates a new `Price` row, updates status to `APPROVED`).
+- Rejection records the reason, user, and timestamp (status to `REJECTED`).
+- All actions are logged in the `audit_log` table for traceability.
+- A `PriceHistory` entry is created only on approval.
+
+---
+
+## 5. Historization Logic
+
+- Every approved price change creates a `PriceHistory` entry:
+    - Links to the `price_change_request` (one-to-one)
+    - Stores previous and new price IDs and amounts
+    - Records who applied the change and when
+- The history is immutable and auditable.
+
+---
+
+## 6. MVP Choices & Future Evolutions
+
+### MVP Choices
+- No modification or cancellation after approval/rejection
+- No multi-step validation (single approval)
+- No scheduled future application (applies immediately)
+- Only admin users can approve/reject
+
+### Future Evolutions
+- Multi-level approval workflow
+- Scheduled price changes (effective date in future)
+- Notification system (email, UI alerts)
+- Bulk approval/rejection
+- Enhanced audit trail (with more context)
+
+---
+
+## Acceptance Criteria
+
+- The workflow is understandable without reading the code
+- Statuses are documented
+- Endpoints are listed
+- Historization logic is explained
+- MVP limitations are explicit


### PR DESCRIPTION
## Context

This PR implements Sprint 4 of the Pricing Control Tower project.

It adds the full price change request workflow: creation, listing, approval, application, rejection, history, auditability, and manual validation.

## Tickets

- T67 — Create `price_change_request` table
- T68 — Add `price_change_request` constraints
- T69 — Create `price_history` table
- T70 — Create `audit_log` table
- T71 — Add `PriceChangeRequest` model
- T72 — Add `PriceHistory` and `AuditLog` models
- T73 — Add Pydantic schemas
- T74 — Implement request creation logic
- T75 — Add `POST /price-change-requests`
- T76 — Add `GET /price-change-requests`
- T77 — Implement approve and apply logic
- T78 — Add `POST /price-change-requests/{id}/approve`
- T79 — Implement reject logic
- T80 — Add `POST /price-change-requests/{id}/reject`
- T81 — Add `GET /price-history`
- T82 — Document workflow
- T83 — Add manual validation script

## Changes

- Added workflow database tables and constraints.
- Added backend models and Pydantic schemas.
- Added endpoints for price change requests and price history.
- Implemented approve/apply workflow.
- Implemented reject workflow.
- Added audit logs for workflow actions.
- Added price history for applied changes.
- Added manual validation script.

## Tests

- [x] Manual API tests
- [x] Manual SQL checks
- [x] Manual workflow validation script
- [x] Python compilation check

Commands:

```bash
uv run python -m compileall app
./scripts/manual_validate_price_workflow.sh

Results
A valid request can be created with PENDING status.
An approved request becomes APPLIED.
The previous price is closed.
A new price is created.
price_history stores before/after values.
A rejected request becomes REJECTED.
Rejected requests do not modify prices.
audit_log stores creation, approval, application, and rejection actions.
Invalid transitions return 409 Conflict.
Review notes
For the MVP, approval applies the price immediately.
Only PENDING requests can be approved or rejected.
Store-level changes do not impact country-level prices.
Authentication and role-based authorization will be handled later.